### PR TITLE
Fix unrestricted traverse depth and silent exception handling

### DIFF
--- a/src/axon/cli/main.py
+++ b/src/axon/cli/main.py
@@ -224,7 +224,7 @@ def context(
 @app.command()
 def impact(
     target: str = typer.Argument(..., help="Symbol to analyze blast radius for."),
-    depth: int = typer.Option(3, "--depth", "-d", help="Traversal depth."),
+    depth: int = typer.Option(3, "--depth", "-d", min=1, max=10, help="Traversal depth (1-10)."),
 ) -> None:
     """Show blast radius of changing a symbol."""
     from axon.mcp.tools import handle_impact

--- a/src/axon/core/storage/kuzu_backend.py
+++ b/src/axon/core/storage/kuzu_backend.py
@@ -210,6 +210,8 @@ class KuzuBackend:
         )
         return self._query_nodes(query, parameters={"nid": node_id})
 
+    _MAX_BFS_DEPTH = 10
+
     def traverse(self, start_id: str, depth: int, direction: str = "callers") -> list[GraphNode]:
         """BFS traversal through CALLS edges up to *depth* hops.
 
@@ -218,6 +220,7 @@ class KuzuBackend:
                        ``"callees"`` follows outgoing CALLS (dependencies).
         """
         assert self._conn is not None
+        depth = min(depth, self._MAX_BFS_DEPTH)
         if _table_for_id(start_id) is None:
             return []
 

--- a/src/axon/mcp/server.py
+++ b/src/axon/mcp/server.py
@@ -27,6 +27,7 @@ from mcp.types import Resource, TextContent, Tool
 from axon.core.storage.kuzu_backend import KuzuBackend
 from axon.mcp.resources import get_dead_code_list, get_overview, get_schema
 from axon.mcp.tools import (
+    MAX_TRAVERSE_DEPTH,
     handle_context,
     handle_cypher,
     handle_dead_code,
@@ -137,8 +138,10 @@ TOOLS: list[Tool] = [
                 },
                 "depth": {
                     "type": "integer",
-                    "description": "Maximum traversal depth (default 3).",
+                    "description": f"Maximum traversal depth (default 3, max {MAX_TRAVERSE_DEPTH}).",
                     "default": 3,
+                    "minimum": 1,
+                    "maximum": MAX_TRAVERSE_DEPTH,
                 },
             },
             "required": ["symbol"],


### PR DESCRIPTION
## Summary

- **Enforce max BFS depth of 10** at three layers — JSON Schema validation, `handle_impact()` clamping, and a safety cap in `traverse()` itself — to prevent resource exhaustion from arbitrarily deep traversals. CLI also rejects out-of-range values via Typer `min`/`max`. (Fixes #2)

- **Replace silent `except Exception: pass`** in `handle_detect_changes` with `logger.warning()` and caller-visible error messages, so DB failures are no longer indistinguishable from legitimate "no symbols found" results. (Fixes #3)

## Changes

| File | What |
|---|---|
| `src/axon/mcp/tools.py` | Add logging, `MAX_TRAVERSE_DEPTH`, depth clamping, exception surfacing |
| `src/axon/mcp/server.py` | Add `minimum`/`maximum` to JSON Schema for `axon_impact` |
| `src/axon/core/storage/kuzu_backend.py` | Add `_MAX_BFS_DEPTH` safety cap in `traverse()` |
| `src/axon/cli/main.py` | Add `min=1, max=10` to `--depth` option |

## Test plan

- [x] All 533 existing tests pass
- [ ] `axon impact <symbol> --depth 50` → Typer rejects with validation error
- [ ] `axon impact <symbol> --depth 3` → Works as before
- [ ] MCP `axon_impact` with `depth: 999` → Clamped to 10, returns results normally
- [ ] MCP `axon_detect_changes` with a broken DB → Returns `(error querying symbols: ...)` instead of silent empty
