### PR TITLE
fix: TSX grammar, JS test detection, and Cypher injection

### DIFF
--- a/src/axon/config/languages.py
+++ b/src/axon/config/languages.py
@@ -7,7 +7,7 @@ from pathlib import Path
 SUPPORTED_EXTENSIONS: dict[str, str] = {
     ".py": "python",
     ".ts": "typescript",
-    ".tsx": "typescript",
+    ".tsx": "tsx",
     ".js": "javascript",
     ".jsx": "javascript",
     ".mjs": "javascript",

--- a/src/axon/core/ingestion/dead_code.py
+++ b/src/axon/core/ingestion/dead_code.py
@@ -34,9 +34,19 @@ def _is_test_class(name: str) -> bool:
 def _is_test_file(file_path: str) -> bool:
     """Return ``True`` if the file is in a test directory or is a test file.
 
-    Matches paths containing ``/tests/`` or files named ``test_*.py``.
+    Matches Python conventions (``/tests/``, ``test_*.py``, ``conftest.py``)
+    and JavaScript/TypeScript conventions (``__tests__/``, ``*.test.*``,
+    ``*.spec.*``).
     """
-    return "/tests/" in file_path or "/test_" in file_path or file_path.endswith("conftest.py")
+    return (
+        "/tests/" in file_path
+        or "/test/" in file_path
+        or "/__tests__/" in file_path
+        or "/test_" in file_path
+        or ".test." in file_path
+        or ".spec." in file_path
+        or file_path.endswith("conftest.py")
+    )
 
 def _is_dunder(name: str) -> bool:
     """Return ``True`` if *name* is a dunder (double-underscore) method.

--- a/src/axon/core/ingestion/imports.py
+++ b/src/axon/core/ingestion/imports.py
@@ -22,7 +22,7 @@ from axon.core.parsers.base import ImportInfo
 
 logger = logging.getLogger(__name__)
 
-_JS_TS_EXTENSIONS = (".ts", ".js", ".tsx", ".jsx")
+_JS_TS_EXTENSIONS = (".ts", ".js", ".tsx", ".jsx", ".mjs", ".cjs")
 
 def build_file_index(graph: KnowledgeGraph) -> dict[str, str]:
     """Build an index mapping file paths to their graph node IDs.
@@ -64,7 +64,7 @@ def resolve_import_path(
 
     if language == "python":
         return _resolve_python(importing_file, import_info, file_index)
-    if language in ("typescript", "javascript"):
+    if language in ("typescript", "tsx", "javascript"):
         return _resolve_js_ts(importing_file, import_info, file_index)
 
     return None
@@ -115,9 +115,11 @@ def _detect_language(file_path: str) -> str:
     suffix = PurePosixPath(file_path).suffix.lower()
     if suffix == ".py":
         return "python"
-    if suffix in (".ts", ".tsx"):
+    if suffix == ".ts":
         return "typescript"
-    if suffix in (".js", ".jsx"):
+    if suffix == ".tsx":
+        return "tsx"
+    if suffix in (".js", ".jsx", ".mjs", ".cjs"):
         return "javascript"
     return ""
 

--- a/src/axon/core/ingestion/parser_phase.py
+++ b/src/axon/core/ingestion/parser_phase.py
@@ -74,6 +74,11 @@ def get_parser(language: str) -> LanguageParser:
 
         parser = TypeScriptParser(dialect="typescript")
 
+    elif language == "tsx":
+        from axon.core.parsers.typescript import TypeScriptParser
+
+        parser = TypeScriptParser(dialect="tsx")
+
     elif language == "javascript":
         from axon.core.parsers.typescript import TypeScriptParser
 
@@ -82,7 +87,7 @@ def get_parser(language: str) -> LanguageParser:
     else:
         raise ValueError(
             f"Unsupported language {language!r}. "
-            f"Expected one of: python, typescript, javascript"
+            f"Expected one of: python, typescript, tsx, javascript"
         )
 
     _PARSER_CACHE[language] = parser

--- a/src/axon/core/ingestion/processes.py
+++ b/src/axon/core/ingestion/processes.py
@@ -107,7 +107,7 @@ def _matches_framework_pattern(node: GraphNode) -> bool:
             if pattern in content:
                 return True
 
-    if language in ("typescript", "ts", "") or node.file_path.endswith(
+    if language in ("typescript", "tsx", "ts", "") or node.file_path.endswith(
         (".ts", ".tsx")
     ):
         if name in ("handler", "middleware"):

--- a/src/axon/core/storage/base.py
+++ b/src/axon/core/storage/base.py
@@ -116,6 +116,10 @@ class StorageBackend(Protocol):
         """Execute a raw backend-specific query string."""
         ...
 
+    def get_symbols_by_file(self, file_path: str) -> list[list[Any]]:
+        """Return symbol rows ``[id, name, file_path, start_line, end_line]`` for a file."""
+        ...
+
     def exact_name_search(self, name: str, limit: int = 5) -> list[SearchResult]:
         """Search for nodes with an exact name match."""
         ...

--- a/src/axon/core/storage/kuzu_backend.py
+++ b/src/axon/core/storage/kuzu_backend.py
@@ -321,6 +321,23 @@ class KuzuBackend:
             rows.append(result.get_next())
         return rows
 
+    def get_symbols_by_file(self, file_path: str) -> list[list[Any]]:
+        """Return symbol rows for a given file using parameterized queries."""
+        assert self._conn is not None
+        all_rows: list[list[Any]] = []
+        for table in _SEARCHABLE_TABLES:
+            try:
+                result = self._conn.execute(
+                    f"MATCH (n:{table}) WHERE n.file_path = $fp AND n.start_line > 0 "
+                    f"RETURN n.id, n.name, n.file_path, n.start_line, n.end_line",
+                    parameters={"fp": file_path},
+                )
+                while result.has_next():
+                    all_rows.append(result.get_next())
+            except Exception:
+                logger.debug("get_symbols_by_file failed for table %s", table, exc_info=True)
+        return all_rows
+
     def exact_name_search(self, name: str, limit: int = 5) -> list[SearchResult]:
         """Search for nodes with an exact name match across all searchable tables.
 

--- a/src/axon/mcp/tools.py
+++ b/src/axon/mcp/tools.py
@@ -394,11 +394,7 @@ def handle_detect_changes(storage: StorageBackend, diff: str) -> str:
     for file_path, ranges in changed_files.items():
         affected_symbols = []
         try:
-            rows = storage.execute_raw(
-                f"MATCH (n) WHERE n.file_path = '{_escape_cypher(file_path)}' "
-                f"AND n.start_line > 0 "
-                f"RETURN n.id, n.name, n.file_path, n.start_line, n.end_line"
-            )
+            rows = storage.get_symbols_by_file(file_path)
             for row in rows or []:
                 node_id = row[0] or ""
                 name = row[1] or ""

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -139,7 +139,7 @@ class TestGetLanguage:
         assert get_language("components/App.ts") == "typescript"
 
     def test_typescript_tsx(self) -> None:
-        assert get_language("components/App.tsx") == "typescript"
+        assert get_language("components/App.tsx") == "tsx"
 
     def test_javascript_js(self) -> None:
         assert get_language("index.js") == "javascript"

--- a/tests/core/test_storage_base.py
+++ b/tests/core/test_storage_base.py
@@ -147,6 +147,9 @@ class TestStorageBackend:
             def bulk_load(self, graph):
                 pass
 
+            def get_symbols_by_file(self, file_path):
+                return []
+
         assert isinstance(_DummyBackend(), StorageBackend)
 
     def test_non_conforming_class_fails(self) -> None:

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -328,9 +328,8 @@ index abc1234..def5678 100644
 class TestHandleDetectChanges:
     def test_parses_diff(self, mock_storage):
         """Successfully parses diff and identifies changed files."""
-        # handle_detect_changes now uses execute_raw() with a Cypher query
-        # to find symbols in the changed file.
-        mock_storage.execute_raw.return_value = [
+        # handle_detect_changes uses get_symbols_by_file() with parameterized queries.
+        mock_storage.get_symbols_by_file.return_value = [
             ["function:src/auth.py:validate", "validate", "src/auth.py", 10, 30],
         ]
 
@@ -351,7 +350,7 @@ class TestHandleDetectChanges:
 
     def test_no_symbols_in_changed_lines(self, mock_storage):
         """Reports file but no symbols when nothing overlaps."""
-        mock_storage.execute_raw.return_value = []
+        mock_storage.get_symbols_by_file.return_value = []
         result = handle_detect_changes(mock_storage, SAMPLE_DIFF)
         assert "src/auth.py" in result
         assert "no indexed symbols" in result


### PR DESCRIPTION
## Summary

Three bug fixes discovered while using Axon on a large multi-language codebase (259 PHP, 191 JS/JSX, 131 HTML files):

- **TSX parsing fix**: `.tsx` files were mapped to `"typescript"` in `SUPPORTED_EXTENSIONS`, causing them to parse with the TypeScript grammar instead of the TSX grammar. This silently produces incomplete/incorrect ASTs for files containing JSX syntax. Now correctly maps `.tsx` → `"tsx"` and routes through `TypeScriptParser(dialect="tsx")`.

- **JS/TS test file detection**: `dead_code._is_test_file()` only matched Python conventions (`/tests/`, `test_*.py`, `conftest.py`). JavaScript/TypeScript projects use `__tests__/`, `*.test.*`, `*.spec.*`, and `/test/` — all of which were being flagged as dead code. Added these patterns to reduce false positives.

- **Cypher injection vulnerability**: `handle_detect_changes()` interpolated file paths from git diff output directly into Cypher query strings using `f"...'{_escape_cypher(file_path)}'..."`. While `_escape_cypher` handles basic escaping, this is still vulnerable to injection via crafted file names. Replaced with a new `get_symbols_by_file()` method on `StorageBackend` that uses parameterized queries (`$fp` parameter).

- **Bonus**: Added `.mjs`/`.cjs` to `_JS_TS_EXTENSIONS` for import resolution of ES module and CommonJS files.

## Test plan

- [x] Updated `test_typescript_tsx` to expect `"tsx"` instead of `"typescript"`
- [x] Updated `TestStorageBackend.test_runtime_checkable` to include `get_symbols_by_file`
- [x] Updated `TestHandleDetectChanges` to mock `get_symbols_by_file` instead of `execute_raw`
- [x] 518 tests passing (full suite minus embedding model download tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)