### PR TITLE
fix: preserve reindex edges, fire global phases on timeout, index CommonJS exports

### DIFF
--- a/src/axon/core/ingestion/pipeline.py
+++ b/src/axon/core/ingestion/pipeline.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 from axon.config.ignore import load_gitignore
 from axon.core.graph.graph import KnowledgeGraph
-from axon.core.graph.model import NodeLabel
+from axon.core.graph.model import GraphRelationship, NodeLabel
 from axon.core.embeddings.embedder import embed_graph
 from axon.core.ingestion.calls import process_calls
 from axon.core.ingestion.community import process_communities
@@ -209,6 +209,15 @@ def reindex_files(
     KnowledgeGraph
         The partial in-memory graph containing only the reindexed files.
     """
+    # DETACH DELETE drops inbound edges from unchanged files — save them
+    # before deletion and re-insert after rebuild.
+    changed_files = {entry.path for entry in file_entries}
+    saved_edges: list[GraphRelationship] = []
+    for fp in changed_files:
+        saved_edges.extend(
+            storage.get_inbound_cross_file_edges(fp, exclude_source_files=changed_files)
+        )
+
     for entry in file_entries:
         storage.remove_nodes_by_file(entry.path)
 
@@ -223,6 +232,10 @@ def reindex_files(
 
     storage.add_nodes(list(graph.iter_nodes()))
     storage.add_relationships(list(graph.iter_relationships()))
+
+    if saved_edges:
+        storage.add_relationships(saved_edges)
+
     storage.rebuild_fts_indexes()
 
     return graph

--- a/src/axon/core/ingestion/watcher.py
+++ b/src/axon/core/ingestion/watcher.py
@@ -219,6 +219,7 @@ async def watch_repo(
     async for changes in watchfiles.awatch(
         repo_path,
         rust_timeout=_POLL_INTERVAL_MS,
+        yield_on_timeout=True,
         stop_event=stop_event,
     ):
         # --- Tier 1: Immediate file-local reindex ---

--- a/src/axon/core/parsers/typescript.py
+++ b/src/axon/core/parsers/typescript.py
@@ -151,7 +151,8 @@ class TypeScriptParser(LanguageParser):
     def _maybe_extract_module_exports(
         self, node: Node, source: str, result: ParseResult
     ) -> None:
-        """Handle ``module.exports = X`` and ``module.exports = { A, B }``."""
+        """Handle ``module.exports = X``, ``module.exports = { A, B }``,
+        and ``exports.name = fn`` / ``module.exports.name = fn``."""
         for child in node.children:
             if child.type != "assignment_expression":
                 continue
@@ -161,20 +162,52 @@ class TypeScriptParser(LanguageParser):
                 continue
 
             left_text = left.text.decode()
-            if left_text not in ("module.exports", "exports"):
+
+            if left_text in ("module.exports", "exports"):
+                if right.type == "identifier":
+                    result.exports.append(right.text.decode())
+                elif right.type == "object":
+                    # module.exports = { Foo, Bar, baz: something }
+                    for prop in right.children:
+                        if prop.type == "shorthand_property_identifier":
+                            result.exports.append(prop.text.decode())
+                        elif prop.type == "pair":
+                            key_node = prop.child_by_field_name("key")
+                            if key_node is not None:
+                                result.exports.append(key_node.text.decode())
                 continue
 
-            if right.type == "identifier":
-                result.exports.append(right.text.decode())
-            elif right.type == "object":
-                # module.exports = { Foo, Bar, baz: something }
-                for prop in right.children:
-                    if prop.type == "shorthand_property_identifier":
-                        result.exports.append(prop.text.decode())
-                    elif prop.type == "pair":
-                        key_node = prop.child_by_field_name("key")
-                        if key_node is not None:
-                            result.exports.append(key_node.text.decode())
+            # exports.X = fn / module.exports.X = fn
+            if left.type != "member_expression":
+                continue
+            obj_node = left.child_by_field_name("object")
+            prop_node = left.child_by_field_name("property")
+            if obj_node is None or prop_node is None:
+                continue
+            obj_text = obj_node.text.decode()
+            if obj_text not in ("exports", "module.exports"):
+                continue
+
+            sym_name = prop_node.text.decode()
+            result.exports.append(sym_name)
+
+            func_node = self._unwrap_to_function(right)
+            if func_node is not None:
+                start_line = child.start_point[0] + 1
+                end_line = child.end_point[0] + 1
+                content = child.text.decode()
+                signature = self._build_function_signature(func_node, sym_name)
+                result.symbols.append(
+                    SymbolInfo(
+                        name=sym_name,
+                        kind="function",
+                        start_line=start_line,
+                        end_line=end_line,
+                        content=content,
+                        signature=signature,
+                    )
+                )
+                self._extract_function_types(func_node, sym_name, result)
 
     def _extract_function_declaration(
         self, node: Node, source: str, result: ParseResult
@@ -642,6 +675,23 @@ class TypeScriptParser(LanguageParser):
         if return_type:
             sig += return_type
         return sig
+
+    @staticmethod
+    def _unwrap_to_function(node: Node) -> Node | None:
+        """Return the underlying function node, unwrapping wrapper calls.
+
+        Handles direct ``arrow_function`` / ``function_expression`` as well as
+        wrapper patterns like ``asyncHandler(async (req, res) => { ... })``.
+        """
+        if node.type in ("arrow_function", "function_expression"):
+            return node
+        if node.type == "call_expression":
+            args = node.child_by_field_name("arguments")
+            if args is not None:
+                for arg in args.children:
+                    if arg.type in ("arrow_function", "function_expression"):
+                        return arg
+        return None
 
     @staticmethod
     def _find_parent_class_name(node: Node) -> str:

--- a/src/axon/core/storage/base.py
+++ b/src/axon/core/storage/base.py
@@ -65,6 +65,17 @@ class StorageBackend(Protocol):
         """
         ...
 
+    def get_inbound_cross_file_edges(
+        self, file_path: str, exclude_source_files: set[str] | None = None,
+    ) -> list[GraphRelationship]:
+        """Return inbound edges where the target is in *file_path* and the source is not.
+
+        Args:
+            file_path: Target file whose inbound edges to collect.
+            exclude_source_files: Source file paths to skip.
+        """
+        ...
+
     def get_node(self, node_id: str) -> GraphNode | None:
         """Return a single node by ID, or ``None`` if not found."""
         ...

--- a/src/axon/core/storage/kuzu_backend.py
+++ b/src/axon/core/storage/kuzu_backend.py
@@ -153,6 +153,62 @@ class KuzuBackend:
                 logger.debug("Failed to remove nodes from table %s", table, exc_info=True)
         return 0
 
+    def get_inbound_cross_file_edges(
+        self, file_path: str, exclude_source_files: set[str] | None = None,
+    ) -> list[GraphRelationship]:
+        """Return inbound edges where target is in *file_path* and source is not.
+
+        Edges whose source file is in *exclude_source_files* are skipped.
+        """
+        assert self._conn is not None
+        exclude = exclude_source_files or set()
+        edges: list[GraphRelationship] = []
+        try:
+            result = self._conn.execute(
+                "MATCH (caller)-[r:CodeRelation]->(n) "
+                "WHERE n.file_path = $fp AND caller.file_path <> $fp "
+                "RETURN caller.id, caller.file_path, n.id, "
+                "r.rel_type, r.confidence, r.role, "
+                "r.step_number, r.strength, r.co_changes, r.symbols",
+                parameters={"fp": file_path},
+            )
+            while result.has_next():
+                row = result.get_next()
+                src_file: str = row[1] or ""
+                if src_file in exclude:
+                    continue
+                src_id: str = row[0] or ""
+                tgt_id: str = row[2] or ""
+                rel_type_str: str = row[3] or ""
+                rel_type = _REL_TYPE_MAP.get(rel_type_str)
+                if rel_type is None:
+                    continue
+                props: dict[str, Any] = {}
+                if row[4] is not None:
+                    props["confidence"] = float(row[4])
+                if row[5] is not None and row[5] != "":
+                    props["role"] = str(row[5])
+                if row[6] is not None and row[6] != 0:
+                    props["step_number"] = int(row[6])
+                if row[7] is not None and row[7] != 0.0:
+                    props["strength"] = float(row[7])
+                if row[8] is not None and row[8] != 0:
+                    props["co_changes"] = int(row[8])
+                if row[9] is not None and row[9] != "":
+                    props["symbols"] = str(row[9])
+                rel_id = f"{rel_type_str}:{src_id}->{tgt_id}"
+                edges.append(GraphRelationship(
+                    id=rel_id, type=rel_type,
+                    source=src_id, target=tgt_id,
+                    properties=props,
+                ))
+        except Exception:
+            logger.debug(
+                "Failed to query inbound cross-file edges for %s",
+                file_path, exc_info=True,
+            )
+        return edges
+
     def get_node(self, node_id: str) -> GraphNode | None:
         """Return a single node by ID, or ``None`` if not found."""
         assert self._conn is not None


### PR DESCRIPTION
## Summary

Fixes three related issues in the ingestion pipeline:

- **#12 — Incremental reindex loses inbound cross-file edges:** `DETACH DELETE` was dropping inbound edges from unchanged files during incremental reindex. Now saves them before deletion and re-inserts after rebuild.
- **#13 — Watch mode global phases never fire without new file events:** `awatch` with `yield_on_timeout=False` never yielded during silence, so the debounced global phase timer check was dead code. Added `yield_on_timeout=True`.
- **#21 — CommonJS export-assignment patterns not indexed:** `exports.X = fn` and `module.exports.X = fn` patterns now produce function symbols. Unwraps single-level wrappers like `asyncHandler()`.

## Changes

| File | Change |
|---|---|
| `src/axon/core/storage/base.py` | Add `get_inbound_cross_file_edges` to `StorageBackend` protocol |
| `src/axon/core/storage/kuzu_backend.py` | Implement inbound edge query with exclude filter |
| `src/axon/core/ingestion/pipeline.py` | Save/restore inbound edges around `DETACH DELETE` in `reindex_files` |
| `src/axon/core/ingestion/watcher.py` | Add `yield_on_timeout=True` to `awatch` call |
| `src/axon/core/parsers/typescript.py` | Handle `exports.X = fn` in `_maybe_extract_module_exports`, add `_unwrap_to_function` helper |

## Test plan

- [x] Verified #12: reindex `model.py` → 246 inbound edges preserved (was 0 before fix), 56 callers of `GraphNode` retained
- [x] Verified #13: single file edit + 4s silence → global phases fire (was never firing)
- [x] Verified #21: `exports.createProject`, `exports.deleteUser`, `module.exports.listUsers` all produce symbols (was 0)
- [x] Regression: `module.exports = Router`, `module.exports = { foo, bar }` still work

Closes #12, Closes #13, Closes #21