### PR TITLE
feat(parser): track JSX elements as function calls for intra-file resolution

### DIFF
--- a/src/axon/core/parsers/typescript.py
+++ b/src/axon/core/parsers/typescript.py
@@ -112,6 +112,8 @@ class TypeScriptParser(LanguageParser):
             self._maybe_extract_module_exports(node, source, result)
         elif ntype == "method_definition":
             self._extract_method(node, source, result)
+        elif ntype in ("jsx_element", "jsx_self_closing_element"):
+            self._extract_jsx_usage(node, source, result)
 
         for child in node.children:
             self._walk(child, source, result, visited)
@@ -553,6 +555,52 @@ class TypeScriptParser(LanguageParser):
                         arguments=arguments,
                     )
                 )
+
+    def _extract_jsx_usage(
+        self, node: Node, source: str, result: ParseResult
+    ) -> None:
+        """Extract JSX element usage as a call to the component function/class.
+
+        Handles both ``<Foo />`` (self-closing) and ``<Foo>...</Foo>``
+        (opening + closing).  Only upper-case tag names are emitted — lower-case
+        tags (``<div>``, ``<span>``) are native HTML and skipped.
+
+        Dotted components like ``<Ns.Component />`` are emitted with the
+        first segment as ``receiver`` and the second as ``name``.
+        """
+        line = node.start_point[0] + 1
+
+        # For jsx_element, drill into the opening tag to find the name.
+        target_node = node
+        if node.type == "jsx_element":
+            for child in node.children:
+                if child.type == "jsx_opening_element":
+                    target_node = child
+                    break
+
+        # Find the tag name (identifier or member_expression).
+        name_node: Node | None = None
+        for child in target_node.children:
+            if child.type in ("identifier", "member_expression"):
+                name_node = child
+                break
+
+        if name_node is None:
+            return
+
+        tag_text = name_node.text.decode()
+
+        # Skip native HTML tags (lowercase first character).
+        if not tag_text or (tag_text[0].islower() and "." not in tag_text):
+            return
+
+        if "." in tag_text:
+            receiver, _, method = tag_text.partition(".")
+            result.calls.append(
+                CallInfo(name=method, line=line, receiver=receiver)
+            )
+        else:
+            result.calls.append(CallInfo(name=tag_text, line=line))
 
     @staticmethod
     def _extract_identifier_arguments(call_node: Node) -> list[str]:

--- a/tests/core/test_parser_typescript.py
+++ b/tests/core/test_parser_typescript.py
@@ -12,6 +12,10 @@ def ts_parser() -> TypeScriptParser:
 @pytest.fixture
 def js_parser() -> TypeScriptParser:
     return TypeScriptParser(dialect="javascript")
+
+@pytest.fixture
+def tsx_parser() -> TypeScriptParser:
+    return TypeScriptParser(dialect="tsx")
 def test_parse_ts_function_declaration(ts_parser: TypeScriptParser) -> None:
     code = """\
 function greet(name: string): string {
@@ -284,3 +288,88 @@ module.exports = { Foo, Bar };
 
     assert "Foo" in result.exports
     assert "Bar" in result.exports
+
+
+# ── JSX / TSX tests ────────────────────────────────────────────────────
+
+
+def test_jsx_self_closing_element(tsx_parser: TypeScriptParser) -> None:
+    """Self-closing JSX tags like ``<Foo />`` should produce a CallInfo."""
+    code = """\
+const App = () => <SelectField />;
+"""
+    result = tsx_parser.parse(code, "app.tsx")
+
+    call_names = [c.name for c in result.calls]
+    assert "SelectField" in call_names
+
+
+def test_jsx_opening_closing_element(tsx_parser: TypeScriptParser) -> None:
+    """Paired JSX tags like ``<Foo>...</Foo>`` should produce a CallInfo."""
+    code = """\
+const App = () => <Container>hello</Container>;
+"""
+    result = tsx_parser.parse(code, "app.tsx")
+
+    call_names = [c.name for c in result.calls]
+    assert "Container" in call_names
+
+
+def test_jsx_skips_html_tags(tsx_parser: TypeScriptParser) -> None:
+    """Native HTML tags (lowercase) should NOT produce a CallInfo."""
+    code = """\
+const App = () => <div><span>hi</span></div>;
+"""
+    result = tsx_parser.parse(code, "app.tsx")
+
+    call_names = [c.name for c in result.calls]
+    assert "div" not in call_names
+    assert "span" not in call_names
+
+
+def test_jsx_dotted_component(tsx_parser: TypeScriptParser) -> None:
+    """Dotted components like ``<Form.Input />`` emit receiver + name."""
+    code = """\
+const App = () => <Form.Input />;
+"""
+    result = tsx_parser.parse(code, "app.tsx")
+
+    dotted_calls = [c for c in result.calls if c.name == "Input"]
+    assert len(dotted_calls) == 1
+    assert dotted_calls[0].receiver == "Form"
+
+
+def test_jsx_nested_components(tsx_parser: TypeScriptParser) -> None:
+    """Multiple nested JSX components should each produce a CallInfo."""
+    code = """\
+const Page = () => (
+    <Layout>
+        <Header />
+        <Content>
+            <Sidebar />
+        </Content>
+    </Layout>
+);
+"""
+    result = tsx_parser.parse(code, "page.tsx")
+
+    call_names = [c.name for c in result.calls]
+    assert "Layout" in call_names
+    assert "Header" in call_names
+    assert "Content" in call_names
+    assert "Sidebar" in call_names
+
+
+def test_jsx_mixed_with_function_calls(tsx_parser: TypeScriptParser) -> None:
+    """JSX calls and regular function calls should coexist."""
+    code = """\
+const App = () => {
+    const data = fetchData();
+    return <Dashboard items={data} />;
+};
+"""
+    result = tsx_parser.parse(code, "app.tsx")
+
+    call_names = [c.name for c in result.calls]
+    assert "fetchData" in call_names
+    assert "Dashboard" in call_names


### PR DESCRIPTION
## Problem

JSX elements (`<Foo />`, `<Bar>...</Bar>`) are not tracked by the TypeScript 
parser as function calls. This causes **false positive dead code reports** for 
React components defined and used within the same file — a very common pattern 
in TSX codebases.

The root cause is that tree-sitter models JSX tags as `jsx_element` / 
`jsx_self_closing_element` nodes, not `call_expression`, so they were invisible 
to the call tracing pipeline.

## Solution

Added `_extract_jsx_usage()` to the TypeScript parser:

- Dispatches on `jsx_element` and `jsx_self_closing_element` in `_walk()`
- Converts uppercase tag names to `CallInfo` records (same as function calls)
- Skips native HTML tags (lowercase: `<div>`, `<span>`, etc.)
- Supports dotted components (`<Form.Input />`) via `receiver` field

## Tests

Added 6 test cases covering:
- Self-closing elements (`<Foo />`)
- Opening/closing elements (`<Foo>...</Foo>`)
- HTML tag filtering (lowercase skipped)
- Dotted components (`<Ns.Component />`)
- Nested components
- Mixed JSX + regular function calls

All 25 tests pass (19 existing + 6 new).