### PR TITLE
fix: MCP tools query nonexistent KuzuDB relationship tables

### DIFF
--- a/src/axon/cli/main.py
+++ b/src/axon/cli/main.py
@@ -30,10 +30,10 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from axon import __version__
 from axon.core.diff import diff_branches, format_diff
-from axon.core.embeddings.embedder import _DEFAULT_MODEL
+from axon.core.embeddings.embedder import get_effective_embedding_model_name
 from axon.core.ingestion.pipeline import PipelineResult, run_pipeline
-from axon.core.storage.base import EMBEDDING_DIMENSIONS
 from axon.core.ingestion.watcher import ensure_current_embeddings, watch_repo
+from axon.core.storage.base import get_embedding_dimensions
 from axon.core.storage.kuzu_backend import KuzuBackend
 from axon.mcp import tools as mcp_tools
 from axon.mcp.server import main as mcp_main
@@ -50,13 +50,12 @@ UPDATE_CHECK_INTERVAL_SECONDS = 60 * 60 * 24
 UPDATE_CHECK_URL = "https://pypi.org/pypi/axoniq/json"
 UPDATE_CHECK_SKIP_COMMANDS = {"mcp", "serve", "host"}
 
+
 def _load_storage(repo_path: Path | None = None) -> "KuzuBackend":  # noqa: F821
     target = (repo_path or Path.cwd()).resolve()
     db_path = target / ".axon" / "kuzu"
     if not db_path.exists():
-        console.print(
-            f"[red]Error:[/red] No index found at {target}. Run 'axon analyze' first."
-        )
+        console.print(f"[red]Error:[/red] No index found at {target}. Run 'axon analyze' first.")
         raise typer.Exit(code=1)
 
     storage = KuzuBackend()
@@ -182,9 +181,7 @@ def _register_in_global_registry(meta: dict, repo_path: Path) -> None:
 
     registry_meta = dict(meta)
     registry_meta["slug"] = slug
-    (slot / "meta.json").write_text(
-        json.dumps(registry_meta, indent=2) + "\n", encoding="utf-8"
-    )
+    (slot / "meta.json").write_text(json.dumps(registry_meta, indent=2) + "\n", encoding="utf-8")
 
 
 def _build_meta(result: "PipelineResult", repo_path: Path) -> dict:  # noqa: F821
@@ -192,8 +189,8 @@ def _build_meta(result: "PipelineResult", repo_path: Path) -> dict:  # noqa: F82
         "version": __version__,
         "name": repo_path.name,
         "path": str(repo_path),
-        "embedding_model": _DEFAULT_MODEL,
-        "embedding_dimensions": EMBEDDING_DIMENSIONS,
+        "embedding_model": get_effective_embedding_model_name(),
+        "embedding_dimensions": get_embedding_dimensions(),
         "stats": {
             "files": result.files,
             "symbols": result.symbols,
@@ -397,10 +394,12 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
+
 def _version_callback(value: bool) -> None:
     if value:
         console.print(f"Axon v{__version__}")
         raise typer.Exit()
+
 
 @app.callback()
 def main(
@@ -419,7 +418,9 @@ def main(
 
 
 def _initialize_writable_storage(
-    repo_path: Path, *, auto_index: bool = True,
+    repo_path: Path,
+    *,
+    auto_index: bool = True,
 ) -> tuple["KuzuBackend", Path, Path]:  # noqa: F821
     """Open the repo database in read-write mode.
 
@@ -461,6 +462,7 @@ async def _proxy_stdio_to_http_mcp(mcp_url: str) -> None:
     """Bridge a local stdio MCP session to the shared HTTP MCP host."""
     async with stdio_server() as (local_read, local_write):
         async with streamablehttp_client(mcp_url) as (remote_read, remote_write, _):
+
             async def _forward(reader, writer) -> None:
                 async with writer:
                     async for message in reader:
@@ -582,6 +584,7 @@ def _run_shared_host(
         _clear_host_meta(repo_path)
         storage.close()
 
+
 def _run_background_embeddings(
     graph: "KnowledgeGraph",
     db_path: Path,
@@ -589,7 +592,7 @@ def _run_background_embeddings(
     repo_path: Path,
 ) -> None:
     """Generate embeddings in a background thread with its own storage connection."""
-    from axon.core.ingestion.pipeline import _run_embedding_phase, PipelineResult
+    from axon.core.ingestion.pipeline import PipelineResult, _run_embedding_phase
 
     bg_storage = KuzuBackend()
     bg_storage.initialize(db_path)
@@ -618,9 +621,13 @@ def _run_background_embeddings(
 @app.command()
 def analyze(
     path: Path = typer.Argument(Path("."), help="Path to the repository to index."),
-    no_embeddings: bool = typer.Option(False, "--no-embeddings", help="Skip vector embedding generation."),
+    no_embeddings: bool = typer.Option(
+        False, "--no-embeddings", help="Skip vector embedding generation."
+    ),
     foreground_embeddings: bool = typer.Option(
-        False, "--foreground-embeddings", help="Generate embeddings synchronously instead of in the background.",
+        False,
+        "--foreground-embeddings",
+        help="Generate embeddings synchronously instead of in the background.",
     ),
 ) -> None:
     """Index a repository into a knowledge graph."""
@@ -703,6 +710,7 @@ def analyze(
     if not no_embeddings and not run_embeddings_inline:
         embed_thread.join()
 
+
 @app.command()
 def status() -> None:
     """Show index status for current repository."""
@@ -734,11 +742,13 @@ def status() -> None:
     if stats.get("coupled_pairs", 0) > 0:
         console.print(f"  Coupled pairs:  {stats['coupled_pairs']}")
 
+
 @app.command(name="list")
 def list_repos() -> None:
     """List all indexed repositories."""
     result = mcp_tools.handle_list_repos()
     console.print(result)
+
 
 @app.command()
 def clean(
@@ -749,9 +759,7 @@ def clean(
     axon_dir = repo_path / ".axon"
 
     if not axon_dir.exists():
-        console.print(
-            f"[red]Error:[/red] No index found at {repo_path}. Nothing to clean."
-        )
+        console.print(f"[red]Error:[/red] No index found at {repo_path}. Nothing to clean.")
         raise typer.Exit(code=1)
 
     if not force:
@@ -762,6 +770,7 @@ def clean(
 
     shutil.rmtree(axon_dir)
     console.print(f"[green]Deleted[/green] {axon_dir}")
+
 
 @app.command()
 def query(
@@ -774,6 +783,7 @@ def query(
     console.print(result)
     storage.close()
 
+
 @app.command()
 def context(
     name: str = typer.Argument(..., help="Symbol name to inspect."),
@@ -783,6 +793,7 @@ def context(
     result = mcp_tools.handle_context(storage, name)
     console.print(result)
     storage.close()
+
 
 @app.command()
 def impact(
@@ -795,6 +806,7 @@ def impact(
     console.print(result)
     storage.close()
 
+
 @app.command(name="dead-code")
 def dead_code() -> None:
     """List all detected dead code."""
@@ -802,6 +814,7 @@ def dead_code() -> None:
     result = mcp_tools.handle_dead_code(storage)
     console.print(result)
     storage.close()
+
 
 @app.command()
 def cypher(
@@ -812,6 +825,7 @@ def cypher(
     result = mcp_tools.handle_cypher(storage, query)
     console.print(result)
     storage.close()
+
 
 @app.command()
 def setup(
@@ -837,6 +851,7 @@ def setup(
         console.print(json.dumps({"axon": stdio_config}, indent=2))
 
     console.print("\n[dim]Then index your codebase with:[/dim] [cyan]axon analyze .[/cyan]")
+
 
 @app.command()
 def watch() -> None:
@@ -871,9 +886,12 @@ def watch() -> None:
     finally:
         storage.close()
 
+
 @app.command()
 def diff(
-    branch_range: str = typer.Argument(..., help="Branch range for comparison (e.g. main..feature)."),
+    branch_range: str = typer.Argument(
+        ..., help="Branch range for comparison (e.g. main..feature)."
+    ),
 ) -> None:
     """Structural branch comparison."""
     repo_path = Path.cwd().resolve()
@@ -885,6 +903,7 @@ def diff(
 
     console.print(format_diff(result))
 
+
 @app.command()
 def mcp() -> None:
     """Start MCP server (stdio transport)."""
@@ -893,10 +912,16 @@ def mcp() -> None:
 
 @app.command()
 def host(
-    port: int = typer.Option(DEFAULT_PORT, "--port", "-p", help="Port to serve UI and HTTP MCP on."),
-    bind: str = typer.Option(DEFAULT_HOST, "--bind", help="Host interface to bind the shared host to."),
+    port: int = typer.Option(
+        DEFAULT_PORT, "--port", "-p", help="Port to serve UI and HTTP MCP on."
+    ),
+    bind: str = typer.Option(
+        DEFAULT_HOST, "--bind", help="Host interface to bind the shared host to."
+    ),
     no_open: bool = typer.Option(False, "--no-open", help="Don't auto-open browser."),
-    watch: bool = typer.Option(True, "--watch/--no-watch", help="Enable file watching with auto-reindex."),
+    watch: bool = typer.Option(
+        True, "--watch/--no-watch", help="Enable file watching with auto-reindex."
+    ),
     dev: bool = typer.Option(False, "--dev", help="Proxy to Vite dev server for HMR."),
     managed: bool = typer.Option(False, "--managed", hidden=True),
 ) -> None:
@@ -915,9 +940,12 @@ def host(
         already_running_message="[yellow]Axon host already running[/yellow] at {url}",
     )
 
+
 @app.command()
 def serve(
-    watch: bool = typer.Option(False, "--watch", "-w", help="Enable file watching with auto-reindex."),
+    watch: bool = typer.Option(
+        False, "--watch", "-w", help="Enable file watching with auto-reindex."
+    ),
 ) -> None:
     """Start MCP server, optionally with live file watching."""
     if not watch:
@@ -1021,10 +1049,9 @@ def ui(
         console.print("[dim]Dev mode — proxying to Vite on :5173[/dim]")
 
     if watch_files:
+
         async def _run() -> None:
-            config = uvicorn.Config(
-                web_app, host="127.0.0.1", port=port, log_level="warning"
-            )
+            config = uvicorn.Config(web_app, host="127.0.0.1", port=port, log_level="warning")
             server = uvicorn.Server(config)
             stop = asyncio.Event()
 

--- a/src/axon/core/embeddings/embedder.py
+++ b/src/axon/core/embeddings/embedder.py
@@ -100,13 +100,21 @@ class _HttpEmbedder:
 _model_cache: dict[str, "TextEmbedding | _HttpEmbedder"] = {}
 _model_lock = threading.Lock()
 
-_EMBEDDING_BASE_URL = os.environ.get("AXON_EMBEDDING_BASE_URL", "")
-_EMBEDDING_MODEL = os.environ.get("AXON_EMBEDDING_MODEL", "")
-_EMBEDDING_API_KEY = os.environ.get("AXON_EMBEDDING_API_KEY", "unused")
+
+def _configured_embedding_base_url() -> str:
+    return os.environ.get("AXON_EMBEDDING_BASE_URL", "").strip()
+
+
+def _configured_embedding_model() -> str:
+    return os.environ.get("AXON_EMBEDDING_MODEL", "").strip()
+
+
+def _configured_embedding_api_key() -> str:
+    return os.environ.get("AXON_EMBEDDING_API_KEY", "unused")
 
 
 def get_effective_embedding_model_name() -> str:
-    return _EMBEDDING_MODEL or _DEFAULT_MODEL
+    return _configured_embedding_model() or _DEFAULT_MODEL
 
 
 # BGE-small max sequence is 512 tokens (~2000 chars). Truncating long
@@ -116,8 +124,12 @@ _MAX_TEXT_CHARS = 2000
 
 
 def _get_model(model_name: str) -> "TextEmbedding | _HttpEmbedder":
-    if _EMBEDDING_BASE_URL and _EMBEDDING_MODEL:
-        cache_key = f"http:{_EMBEDDING_BASE_URL}:{_EMBEDDING_MODEL}"
+    embedding_base_url = _configured_embedding_base_url()
+    embedding_model = _configured_embedding_model()
+    embedding_api_key = _configured_embedding_api_key()
+
+    if embedding_base_url and embedding_model:
+        cache_key = f"http:{embedding_base_url}:{embedding_model}"
         cached = _model_cache.get(cache_key)
         if cached is not None:
             return cached
@@ -125,7 +137,7 @@ def _get_model(model_name: str) -> "TextEmbedding | _HttpEmbedder":
             cached = _model_cache.get(cache_key)
             if cached is not None:
                 return cached
-            model = _HttpEmbedder(_EMBEDDING_BASE_URL, _EMBEDDING_MODEL, _EMBEDDING_API_KEY)
+            model = _HttpEmbedder(embedding_base_url, embedding_model, embedding_api_key)
             _model_cache[cache_key] = model
             return model
 
@@ -232,16 +244,17 @@ def _normalize_embedding_batch(
 def embed_query(
     query: str,
     model_name: str = _DEFAULT_MODEL,
-    dimensions: int = _DEFAULT_DIMENSIONS,
+    dimensions: int | None = None,
 ) -> list[float] | None:
     if not query or not query.strip():
         return None
+    effective_dimensions = dimensions if dimensions is not None else get_embedding_dimensions()
     try:
         model = _get_model(model_name)
         vectors, _ = _normalize_embedding_batch(
             list(model.query_embed(query)),
             expected_count=1,
-            dimensions=dimensions,
+            dimensions=effective_dimensions,
         )
         return vectors[0]
     except Exception:
@@ -276,7 +289,7 @@ def embed_graph(
     graph: KnowledgeGraph,
     model_name: str = _DEFAULT_MODEL,
     batch_size: int = _DEFAULT_BATCH_SIZE,
-    dimensions: int = _DEFAULT_DIMENSIONS,
+    dimensions: int | None = None,
 ) -> list[NodeEmbedding]:
     all_nodes = [n for n in graph.iter_nodes() if n.label in EMBEDDABLE_LABELS]
     if not all_nodes:
@@ -295,7 +308,8 @@ def embed_graph(
     if not texts:
         return []
 
-    return _embed_node_list(nodes, texts, model_name, batch_size, dimensions)
+    effective_dimensions = dimensions if dimensions is not None else get_embedding_dimensions()
+    return _embed_node_list(nodes, texts, model_name, batch_size, effective_dimensions)
 
 
 def embed_nodes(
@@ -303,7 +317,7 @@ def embed_nodes(
     node_ids: set[str],
     model_name: str = _DEFAULT_MODEL,
     batch_size: int = _DEFAULT_BATCH_SIZE,
-    dimensions: int = _DEFAULT_DIMENSIONS,
+    dimensions: int | None = None,
 ) -> list[NodeEmbedding]:
     if not node_ids:
         return []
@@ -325,4 +339,5 @@ def embed_nodes(
     if not texts:
         return []
 
-    return _embed_node_list(valid_nodes, texts, model_name, batch_size, dimensions)
+    effective_dimensions = dimensions if dimensions is not None else get_embedding_dimensions()
+    return _embed_node_list(valid_nodes, texts, model_name, batch_size, effective_dimensions)

--- a/src/axon/core/embeddings/embedder.py
+++ b/src/axon/core/embeddings/embedder.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 from axon.core.embeddings.text import build_class_method_index, generate_text
 from axon.core.graph.graph import KnowledgeGraph
 from axon.core.graph.model import NodeLabel
-from axon.core.storage.base import EMBEDDING_DIMENSIONS, NodeEmbedding
+from axon.core.storage.base import NodeEmbedding, get_embedding_dimensions
 
 if TYPE_CHECKING:
     from fastembed import TextEmbedding
@@ -104,6 +104,11 @@ _EMBEDDING_BASE_URL = os.environ.get("AXON_EMBEDDING_BASE_URL", "")
 _EMBEDDING_MODEL = os.environ.get("AXON_EMBEDDING_MODEL", "")
 _EMBEDDING_API_KEY = os.environ.get("AXON_EMBEDDING_API_KEY", "unused")
 
+
+def get_effective_embedding_model_name() -> str:
+    return _EMBEDDING_MODEL or _DEFAULT_MODEL
+
+
 # BGE-small max sequence is 512 tokens (~2000 chars). Truncating long
 # descriptions avoids wasting tokenisation and padding time on text that
 # the model would discard anyway.
@@ -143,6 +148,7 @@ def _get_model_cache_clear() -> None:
     """Clear the model cache (used in tests)."""
     with _model_lock:
         _model_cache.clear()
+    get_embedding_dimensions.cache_clear()
 
 
 _get_model.cache_clear = _get_model_cache_clear  # type: ignore[attr-defined]
@@ -160,7 +166,7 @@ EMBEDDABLE_LABELS: frozenset[NodeLabel] = frozenset(
 )
 
 _DEFAULT_MODEL = "nomic-ai/nomic-embed-text-v1.5"
-_DEFAULT_DIMENSIONS = EMBEDDING_DIMENSIONS
+_DEFAULT_DIMENSIONS = get_embedding_dimensions()
 _DEFAULT_BATCH_SIZE = 32
 _MAX_TEXT_CHARS = 8192
 

--- a/src/axon/core/embeddings/embedder.py
+++ b/src/axon/core/embeddings/embedder.py
@@ -12,6 +12,7 @@ richness that makes embedding worthwhile.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import threading
 from typing import TYPE_CHECKING
@@ -26,16 +27,103 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_model_cache: dict[str, "TextEmbedding"] = {}
+
+class _HttpEmbedder:
+    """OpenAI-compatible HTTP embedding client."""
+
+    def __init__(self, base_url: str, model: str, api_key: str = "unused") -> None:
+        self._base_url = base_url.rstrip("/")
+        self._model = model
+        self._api_key = api_key
+
+    def _embed(self, texts: list[str], batch_size: int) -> list[list[float]]:
+        import json
+        import urllib.request
+
+        all_vectors: list[list[float]] = []
+        expected_dim: int | None = None
+        for i in range(0, len(texts), batch_size):
+            batch = texts[i : i + batch_size]
+            body = json.dumps({"input": batch, "model": self._model}).encode()
+            req = urllib.request.Request(
+                f"{self._base_url}/embeddings",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {self._api_key}",
+                },
+            )
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                payload = json.loads(resp.read())
+
+            data = payload.get("data")
+            if not isinstance(data, list):
+                raise ValueError("Embedding response missing 'data' list")
+            if len(data) != len(batch):
+                raise ValueError(
+                    f"Embedding count mismatch: expected {len(batch)}, got {len(data)}"
+                )
+
+            indexed_items: list[tuple[int, object]] = []
+            for raw_index, item in enumerate(data):
+                if not isinstance(item, dict):
+                    raise ValueError("Embedding response item must be an object")
+                embedding = item.get("embedding")
+                index = item.get("index", raw_index)
+                if not isinstance(index, int):
+                    raise ValueError("Embedding response index must be an integer")
+                indexed_items.append((index, embedding))
+
+            indexed_items.sort(key=lambda pair: pair[0])
+            actual_indexes = [index for index, _ in indexed_items]
+            expected_indexes = list(range(len(batch)))
+            if actual_indexes != expected_indexes:
+                raise ValueError(
+                    f"Embedding response indexes mismatch: expected {expected_indexes}, got {actual_indexes}"
+                )
+
+            vectors, expected_dim = _normalize_embedding_batch(
+                [embedding for _, embedding in indexed_items],
+                expected_count=len(batch),
+                expected_dim=expected_dim,
+            )
+            all_vectors.extend(vectors)
+        return all_vectors
+
+    def query_embed(self, text: str):
+        return iter(self._embed([text], batch_size=1))
+
+    def passage_embed(self, texts: list[str], batch_size: int = 32):
+        return iter(self._embed(texts, batch_size=batch_size))
+
+
+_model_cache: dict[str, "TextEmbedding | _HttpEmbedder"] = {}
 _model_lock = threading.Lock()
 
-# BGE-small max sequence is 512 tokens (~2000 chars).  Truncating long
+_EMBEDDING_BASE_URL = os.environ.get("AXON_EMBEDDING_BASE_URL", "")
+_EMBEDDING_MODEL = os.environ.get("AXON_EMBEDDING_MODEL", "")
+_EMBEDDING_API_KEY = os.environ.get("AXON_EMBEDDING_API_KEY", "unused")
+
+# BGE-small max sequence is 512 tokens (~2000 chars). Truncating long
 # descriptions avoids wasting tokenisation and padding time on text that
 # the model would discard anyway.
 _MAX_TEXT_CHARS = 2000
 
 
-def _get_model(model_name: str) -> "TextEmbedding":
+def _get_model(model_name: str) -> "TextEmbedding | _HttpEmbedder":
+    if _EMBEDDING_BASE_URL and _EMBEDDING_MODEL:
+        cache_key = f"http:{_EMBEDDING_BASE_URL}:{_EMBEDDING_MODEL}"
+        cached = _model_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        with _model_lock:
+            cached = _model_cache.get(cache_key)
+            if cached is not None:
+                return cached
+            model = _HttpEmbedder(_EMBEDDING_BASE_URL, _EMBEDDING_MODEL, _EMBEDDING_API_KEY)
+            _model_cache[cache_key] = model
+            return model
+
     cached = _model_cache.get(model_name)
     if cached is not None:
         return cached
@@ -45,8 +133,6 @@ def _get_model(model_name: str) -> "TextEmbedding":
             return cached
         from fastembed import TextEmbedding
 
-        # Cap ONNX threads to avoid saturating all CPU cores.
-        # Default to half the available cores (minimum 2).
         max_threads = max(2, os.cpu_count() // 2) if os.cpu_count() else 2
         model = TextEmbedding(model_name=model_name, threads=max_threads)
         _model_cache[model_name] = model
@@ -61,7 +147,6 @@ def _get_model_cache_clear() -> None:
 
 _get_model.cache_clear = _get_model_cache_clear  # type: ignore[attr-defined]
 
-# Labels worth embedding — skip Folder, Community, Process (structural only).
 EMBEDDABLE_LABELS: frozenset[NodeLabel] = frozenset(
     {
         NodeLabel.FILE,
@@ -75,9 +160,67 @@ EMBEDDABLE_LABELS: frozenset[NodeLabel] = frozenset(
 )
 
 _DEFAULT_MODEL = "nomic-ai/nomic-embed-text-v1.5"
-_DEFAULT_DIMENSIONS = EMBEDDING_DIMENSIONS  # 384 via Matryoshka
+_DEFAULT_DIMENSIONS = EMBEDDING_DIMENSIONS
 _DEFAULT_BATCH_SIZE = 32
 _MAX_TEXT_CHARS = 8192
+
+
+def _normalize_embedding_vector(vector: object, *, dimensions: int | None = None) -> list[float]:
+    raw_values = getattr(vector, "tolist")() if hasattr(vector, "tolist") else vector
+    if isinstance(raw_values, (str, bytes)):
+        raise ValueError("Embedding vector must be a sequence of numeric values")
+
+    try:
+        values = list(raw_values)  # type: ignore[arg-type]
+    except TypeError as exc:
+        raise ValueError("Embedding vector must be iterable") from exc
+
+    if not values:
+        raise ValueError("Embedding vector must not be empty")
+
+    normalized: list[float] = []
+    for value in values:
+        number = float(value)
+        if not math.isfinite(number):
+            raise ValueError(f"Embedding vector contains non-finite value: {number}")
+        normalized.append(number)
+
+    if dimensions is not None:
+        normalized = normalized[:dimensions]
+        if len(normalized) != dimensions:
+            raise ValueError(
+                f"Expected embedding of {dimensions} dimensions, got {len(normalized)}"
+            )
+
+    return normalized
+
+
+def _normalize_embedding_batch(
+    vectors: list[object],
+    *,
+    expected_count: int,
+    expected_dim: int | None = None,
+    dimensions: int | None = None,
+) -> tuple[list[list[float]], int]:
+    if len(vectors) != expected_count:
+        raise ValueError(f"Embedding count mismatch: expected {expected_count}, got {len(vectors)}")
+
+    normalized_vectors: list[list[float]] = []
+    dimension = expected_dim
+    for vector in vectors:
+        normalized = _normalize_embedding_vector(vector, dimensions=dimensions)
+        if dimension is None:
+            dimension = len(normalized)
+        elif len(normalized) != dimension:
+            raise ValueError(
+                f"Embedding dimension mismatch: expected {dimension}, got {len(normalized)}"
+            )
+        normalized_vectors.append(normalized)
+
+    if dimension is None:
+        raise ValueError("Expected at least one embedding vector")
+
+    return normalized_vectors, dimension
 
 
 def embed_query(
@@ -85,13 +228,16 @@ def embed_query(
     model_name: str = _DEFAULT_MODEL,
     dimensions: int = _DEFAULT_DIMENSIONS,
 ) -> list[float] | None:
-    """Embed a single query string, returning ``None`` on failure."""
     if not query or not query.strip():
         return None
     try:
         model = _get_model(model_name)
-        vec = next(iter(model.query_embed(query)))
-        return vec[:dimensions].tolist()
+        vectors, _ = _normalize_embedding_batch(
+            list(model.query_embed(query)),
+            expected_count=1,
+            dimensions=dimensions,
+        )
+        return vectors[0]
     except Exception:
         logger.warning("embed_query failed", exc_info=True)
         return None
@@ -104,22 +250,19 @@ def _embed_node_list(
     batch_size: int,
     dimensions: int,
 ) -> list[NodeEmbedding]:
-    """Embed a list of nodes with their corresponding texts."""
     if not texts:
         return []
 
     model = _get_model(model_name)
-    vectors = list(model.passage_embed(texts, batch_size=batch_size))
+    vectors, _ = _normalize_embedding_batch(
+        list(model.passage_embed(texts, batch_size=batch_size)),
+        expected_count=len(nodes),
+        dimensions=dimensions,
+    )
 
     results: list[NodeEmbedding] = []
     for node, vector in zip(nodes, vectors):
-        results.append(
-            NodeEmbedding(
-                node_id=node.id,
-                embedding=vector[:dimensions].tolist(),
-            )
-        )
-
+        results.append(NodeEmbedding(node_id=node.id, embedding=vector))
     return results
 
 
@@ -129,25 +272,6 @@ def embed_graph(
     batch_size: int = _DEFAULT_BATCH_SIZE,
     dimensions: int = _DEFAULT_DIMENSIONS,
 ) -> list[NodeEmbedding]:
-    """Generate embeddings for all embeddable nodes in the graph.
-
-    Uses fastembed's :class:`TextEmbedding` model for batch encoding.
-    Each embeddable node is converted to a natural-language description
-    via :func:`generate_text`, then embedded in a single batch call.
-
-    Args:
-        graph: The knowledge graph whose nodes should be embedded.
-        model_name: The fastembed model identifier.  Defaults to
-            ``"nomic-ai/nomic-embed-text-v1.5"``.
-        batch_size: Number of texts to encode per batch.  Defaults to 128.
-        dimensions: Number of dimensions for Matryoshka truncation.
-            Defaults to 384.
-
-    Returns:
-        A list of :class:`NodeEmbedding` instances, one per embeddable node,
-        each carrying the node's ID and its embedding vector as a plain
-        Python ``list[float]``.
-    """
     all_nodes = [n for n in graph.iter_nodes() if n.label in EMBEDDABLE_LABELS]
     if not all_nodes:
         return []
@@ -175,7 +299,6 @@ def embed_nodes(
     batch_size: int = _DEFAULT_BATCH_SIZE,
     dimensions: int = _DEFAULT_DIMENSIONS,
 ) -> list[NodeEmbedding]:
-    """Like :func:`embed_graph`, but only for the given *node_ids*."""
     if not node_ids:
         return []
     nodes = [graph.get_node(nid) for nid in node_ids]

--- a/src/axon/core/ingestion/watcher.py
+++ b/src/axon/core/ingestion/watcher.py
@@ -23,8 +23,10 @@ import watchfiles
 
 from axon.config.ignore import load_gitignore, should_ignore
 from axon.config.languages import is_supported
-from axon.core.embeddings.embedder import _DEFAULT_MODEL, embed_graph, embed_nodes
-from axon.core.storage.base import EMBEDDING_DIMENSIONS
+from axon.core.embeddings.embedder import (
+    embed_graph,
+    embed_nodes,
+)
 from axon.core.graph.graph import KnowledgeGraph
 from axon.core.graph.model import NodeLabel, RelType
 from axon.core.ingestion.community import process_communities
@@ -33,7 +35,7 @@ from axon.core.ingestion.dead_code import process_dead_code
 from axon.core.ingestion.pipeline import reindex_files
 from axon.core.ingestion.processes import process_processes
 from axon.core.ingestion.walker import FileEntry, read_file
-from axon.core.storage.base import StorageBackend
+from axon.core.storage.base import StorageBackend, get_embedding_dimensions
 
 logger = logging.getLogger(__name__)
 
@@ -64,19 +66,24 @@ def _load_embedding_meta(repo_path: Path) -> dict | None:
 
 
 def ensure_current_embeddings(storage: StorageBackend, repo_path: Path) -> bool:
-    """Re-embed the full graph when the stored embedding model is outdated."""
+    """Re-embed the full graph when the stored embedding config is outdated."""
     meta = _load_embedding_meta(repo_path)
     if meta is None:
         return False
 
+    current_dimensions = get_embedding_dimensions()
+    current_model = get_effective_embedding_model_name()
     stored_model = meta.get("embedding_model")
-    if stored_model == _DEFAULT_MODEL:
+    stored_dimensions = meta.get("embedding_dimensions")
+    if stored_model == current_model and stored_dimensions == current_dimensions:
         return False
 
     logger.info(
-        "Embedding model changed from %s to %s, re-embedding all symbols",
+        "Embedding config changed from model=%s dims=%s to model=%s dims=%s, re-embedding all symbols",
         stored_model or "unknown",
-        _DEFAULT_MODEL,
+        stored_dimensions or "unknown",
+        current_model,
+        current_dimensions,
     )
 
     try:
@@ -85,8 +92,8 @@ def ensure_current_embeddings(storage: StorageBackend, repo_path: Path) -> bool:
         if embeddings:
             storage.store_embeddings(embeddings)
 
-        meta["embedding_model"] = _DEFAULT_MODEL
-        meta["embedding_dimensions"] = EMBEDDING_DIMENSIONS
+        meta["embedding_model"] = current_model
+        meta["embedding_dimensions"] = current_dimensions
         _embedding_meta_path(repo_path).write_text(
             json.dumps(meta, indent=2) + "\n",
             encoding="utf-8",
@@ -212,13 +219,11 @@ def _run_incremental_global_phases(
     logger.info("Dead code: %d", num_dead)
 
     if not small_change:
-        new_nodes = (
-            list(graph.get_nodes_by_label(NodeLabel.COMMUNITY))
-            + list(graph.get_nodes_by_label(NodeLabel.PROCESS))
+        new_nodes = list(graph.get_nodes_by_label(NodeLabel.COMMUNITY)) + list(
+            graph.get_nodes_by_label(NodeLabel.PROCESS)
         )
-        new_rels = (
-            list(graph.get_relationships_by_type(RelType.MEMBER_OF))
-            + list(graph.get_relationships_by_type(RelType.STEP_IN_PROCESS))
+        new_rels = list(graph.get_relationships_by_type(RelType.MEMBER_OF)) + list(
+            graph.get_relationships_by_type(RelType.STEP_IN_PROCESS)
         )
         if new_nodes:
             storage.add_nodes(new_nodes)
@@ -267,6 +272,7 @@ async def watch_repo(
     period of QUIET_PERIOD seconds with no new changes. Coupling runs
     only when new git commits are detected.
     """
+
     async def _run_sync(fn, *args):
         if lock is not None:
             async with lock:
@@ -297,7 +303,11 @@ async def watch_repo(
 
         if changed_paths:
             count, reindexed = await _run_sync(
-                _reindex_files, changed_paths, repo_path, storage, gitignore,
+                _reindex_files,
+                changed_paths,
+                repo_path,
+                storage,
+                gitignore,
             )
             if reindexed:
                 dirty_files |= reindexed
@@ -328,7 +338,10 @@ async def watch_repo(
                     logger.info("Running incremental global phases...")
                     await _run_sync(
                         _run_incremental_global_phases,
-                        storage, repo_path, snapshot, run_coupling,
+                        storage,
+                        repo_path,
+                        snapshot,
+                        run_coupling,
                     )
             except Exception:
                 logger.exception("Global phases failed; re-queueing dirty files")

--- a/src/axon/core/ingestion/watcher.py
+++ b/src/axon/core/ingestion/watcher.py
@@ -26,6 +26,7 @@ from axon.config.languages import is_supported
 from axon.core.embeddings.embedder import (
     embed_graph,
     embed_nodes,
+    get_effective_embedding_model_name,
 )
 from axon.core.graph.graph import KnowledgeGraph
 from axon.core.graph.model import NodeLabel, RelType

--- a/src/axon/core/storage/base.py
+++ b/src/axon/core/storage/base.py
@@ -7,7 +7,9 @@ supporting data classes for search results and embeddings.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
@@ -26,9 +28,39 @@ class SearchResult:
     label: str = ""
     snippet: str = ""
 
-EMBEDDING_DIMENSIONS: int = 384
-"""Number of dimensions expected for all embedding vectors."""
 
+EMBEDDING_DIMENSIONS: int = 384
+"""Default embedding dimensions for local Matryoshka-truncated embeddings."""
+
+_REMOTE_MODEL_DIMENSIONS: dict[str, int] = {
+    "BAAI/bge-large-en-v1.5": 1024,
+    "BAAI/bge-base-en-v1.5": 768,
+    "BAAI/bge-small-en-v1.5": 384,
+    "nomic-ai/nomic-embed-text-v1.5": 768,
+}
+
+
+@lru_cache(maxsize=1)
+def get_embedding_dimensions() -> int:
+    """Return the active embedding dimensionality for the current process."""
+    configured = os.environ.get("AXON_EMBEDDING_DIMENSIONS", "").strip()
+    if configured:
+        try:
+            value = int(configured)
+        except ValueError as exc:
+            raise ValueError(
+                f"AXON_EMBEDDING_DIMENSIONS must be an integer, got {configured!r}"
+            ) from exc
+        if value <= 0:
+            raise ValueError("AXON_EMBEDDING_DIMENSIONS must be greater than 0")
+        return value
+
+    base_url = os.environ.get("AXON_EMBEDDING_BASE_URL", "").strip()
+    model = os.environ.get("AXON_EMBEDDING_MODEL", "").strip()
+    if base_url and model:
+        return _REMOTE_MODEL_DIMENSIONS.get(model, EMBEDDING_DIMENSIONS)
+
+    return EMBEDDING_DIMENSIONS
 
 
 @dataclass
@@ -39,11 +71,12 @@ class NodeEmbedding:
     embedding: list[float] = field(default_factory=list)
 
     def __post_init__(self) -> None:
-        if self.embedding and len(self.embedding) != EMBEDDING_DIMENSIONS:
+        expected_dimensions = get_embedding_dimensions()
+        if self.embedding and len(self.embedding) != expected_dimensions:
             raise ValueError(
-                f"Expected embedding of {EMBEDDING_DIMENSIONS} dimensions, "
-                f"got {len(self.embedding)}"
+                f"Expected embedding of {expected_dimensions} dimensions, got {len(self.embedding)}"
             )
+
 
 @runtime_checkable
 class StorageBackend(Protocol):
@@ -79,7 +112,9 @@ class StorageBackend(Protocol):
         ...
 
     def get_inbound_cross_file_edges(
-        self, file_path: str, exclude_source_files: set[str] | None = None,
+        self,
+        file_path: str,
+        exclude_source_files: set[str] | None = None,
     ) -> list[GraphRelationship]:
         """Return inbound edges where the target is in *file_path* and the source is not.
 
@@ -148,9 +183,7 @@ class StorageBackend(Protocol):
         """Full-text search across indexed node content."""
         ...
 
-    def fuzzy_search(
-        self, query: str, limit: int, max_distance: int = 2
-    ) -> list[SearchResult]:
+    def fuzzy_search(self, query: str, limit: int, max_distance: int = 2) -> list[SearchResult]:
         """Fuzzy name search by edit distance."""
         ...
 

--- a/src/axon/core/storage/kuzu_backend.py
+++ b/src/axon/core/storage/kuzu_backend.py
@@ -9,7 +9,6 @@ covers all source-to-target combinations.
 from __future__ import annotations
 
 import csv
-import json
 import hashlib
 import json
 import logging
@@ -24,7 +23,7 @@ import kuzu
 
 from axon.core.graph.graph import KnowledgeGraph
 from axon.core.graph.model import GraphNode, GraphRelationship, NodeLabel, RelType
-from axon.core.storage.base import NodeEmbedding, SearchResult
+from axon.core.storage.base import NodeEmbedding, SearchResult, get_embedding_dimensions
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +38,7 @@ _LABEL_MAP: dict[str, NodeLabel] = {label.value: label for label in NodeLabel}
 _REL_TYPE_MAP: dict[str, RelType] = {rt.value: rt for rt in RelType}
 
 _SEARCHABLE_TABLES: list[str] = [
-    t for t in _NODE_TABLE_NAMES
-    if t not in ("Folder", "Community", "Process")
+    t for t in _NODE_TABLE_NAMES if t not in ("Folder", "Community", "Process")
 ]
 
 _NODE_PROPERTIES = (
@@ -73,6 +71,7 @@ _REL_PROPERTIES = (
     "symbols STRING"
 )
 
+
 def _serialize_extra_props(props: dict[str, Any] | None) -> str:
     if not props:
         return ""
@@ -97,7 +96,10 @@ def _table_for_id(node_id: str) -> str | None:
     prefix = node_id.split(":", 1)[0]
     return _LABEL_TO_TABLE.get(prefix)
 
-_EMBEDDING_PROPERTIES = "node_id STRING, vec FLOAT[384], PRIMARY KEY(node_id)"
+
+def _embedding_properties(dimensions: int) -> str:
+    return f"node_id STRING, vec FLOAT[{dimensions}], PRIMARY KEY(node_id)"
+
 
 class KuzuBackend:
     """StorageBackend implementation backed by KuzuDB.
@@ -116,11 +118,55 @@ class KuzuBackend:
         self._conn: kuzu.Connection | None = None
         self._lock = threading.Lock()
         self._embeddings_clean: bool = False
+        self._embedding_dimensions: int = get_embedding_dimensions()
 
     def _require_conn(self) -> kuzu.Connection:
         if self._conn is None:
             raise RuntimeError("KuzuBackend.initialize() must be called before use")
         return self._conn
+
+    def _embedding_cast_type(self) -> str:
+        return f"FLOAT[{self._embedding_dimensions}]"
+
+    def _repo_meta_path(self, db_path: Path) -> Path:
+        return db_path.parent / "meta.json"
+
+    def _reset_embedding_table(self) -> None:
+        conn = self._require_conn()
+        for statement in (
+            "DROP TABLE Embedding",
+            "DROP NODE TABLE Embedding",
+        ):
+            try:
+                conn.execute(statement)
+                break
+            except Exception:
+                continue
+        conn.execute(
+            f"CREATE NODE TABLE IF NOT EXISTS Embedding({_embedding_properties(self._embedding_dimensions)})"
+        )
+        self._embeddings_clean = False
+
+    def _ensure_embedding_schema(self, db_path: Path) -> None:
+        meta_path = self._repo_meta_path(db_path)
+        if not meta_path.exists():
+            return
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except Exception:
+            logger.debug("Failed to read embedding metadata during schema check", exc_info=True)
+            return
+
+        stored_dimensions = meta.get("embedding_dimensions")
+        if stored_dimensions == self._embedding_dimensions:
+            return
+
+        logger.info(
+            "Embedding dimensions changed from %s to %s, recreating Embedding table",
+            stored_dimensions,
+            self._embedding_dimensions,
+        )
+        self._reset_embedding_table()
 
     def initialize(
         self,
@@ -135,21 +181,25 @@ class KuzuBackend:
         In read-only mode, schema creation is skipped (database must already exist).
         Retries on lock contention errors with exponential backoff.
         """
+        self._embedding_dimensions = get_embedding_dimensions()
         for attempt in range(max_retries + 1):
             try:
                 self._db = kuzu.Database(str(path), read_only=read_only)
                 self._conn = kuzu.Connection(self._db)
                 if not read_only:
                     self._create_schema()
+                    self._ensure_embedding_schema(path)
                 return
             except RuntimeError as e:
                 if "lock" in str(e).lower() and attempt < max_retries:
                     logger.debug(
                         "Lock contention on attempt %d/%d, retrying in %.1fs",
-                        attempt + 1, max_retries, retry_delay * (2 ** attempt),
+                        attempt + 1,
+                        max_retries,
+                        retry_delay * (2**attempt),
                     )
                     self.close()
-                    time.sleep(retry_delay * (2 ** attempt))
+                    time.sleep(retry_delay * (2**attempt))
                     continue
                 raise
 
@@ -197,7 +247,9 @@ class KuzuBackend:
         return total
 
     def get_inbound_cross_file_edges(
-        self, file_path: str, exclude_source_files: set[str] | None = None,
+        self,
+        file_path: str,
+        exclude_source_files: set[str] | None = None,
     ) -> list[GraphRelationship]:
         """Return inbound edges where target is in *file_path* and source is not.
 
@@ -241,15 +293,20 @@ class KuzuBackend:
                 if row[9] is not None and row[9] != "":
                     props["symbols"] = str(row[9])
                 rel_id = f"{rel_type_str}:{src_id}->{tgt_id}"
-                edges.append(GraphRelationship(
-                    id=rel_id, type=rel_type,
-                    source=src_id, target=tgt_id,
-                    properties=props,
-                ))
+                edges.append(
+                    GraphRelationship(
+                        id=rel_id,
+                        type=rel_type,
+                        source=src_id,
+                        target=tgt_id,
+                        properties=props,
+                    )
+                )
         except Exception:
             logger.warning(
                 "Failed to query inbound cross-file edges for %s",
-                file_path, exc_info=True,
+                file_path,
+                exc_info=True,
             )
         return edges
 
@@ -533,9 +590,7 @@ class KuzuBackend:
         candidates.sort(key=lambda r: (-r.score, r.node_id))
         return candidates[:limit]
 
-    def fuzzy_search(
-        self, query: str, limit: int, max_distance: int = 2
-    ) -> list[SearchResult]:
+    def fuzzy_search(self, query: str, limit: int, max_distance: int = 2) -> list[SearchResult]:
         """Fuzzy name search using Levenshtein edit distance.
 
         Scans all node tables for symbols whose name is within
@@ -607,9 +662,7 @@ class KuzuBackend:
                     parameters={"nid": emb.node_id, "vec": emb.embedding},
                 )
             except Exception:
-                logger.debug(
-                    "store_embeddings failed for node %s", emb.node_id, exc_info=True
-                )
+                logger.debug("store_embeddings failed for node %s", emb.node_id, exc_info=True)
 
     def vector_search(self, vector: list[float], limit: int) -> list[SearchResult]:
         """Find the closest nodes to *vector* using native ``array_cosine_similarity``.
@@ -626,7 +679,7 @@ class KuzuBackend:
                 result = conn.execute(
                     "MATCH (e:Embedding) "
                     "RETURN e.node_id, "
-                    "array_cosine_similarity(e.vec, CAST($vec, 'FLOAT[384]')) AS sim "
+                    f"array_cosine_similarity(e.vec, CAST($vec, '{self._embedding_cast_type()}')) AS sim "
                     "ORDER BY sim DESC LIMIT $lim",
                     parameters={"vec": vector, "lim": limit},
                 )
@@ -690,9 +743,7 @@ class KuzuBackend:
         mapping: dict[str, str] = {}
         try:
             with self._lock:
-                result = conn.execute(
-                    "MATCH (n:File) RETURN n.file_path, n.content"
-                )
+                result = conn.execute("MATCH (n:File) RETURN n.file_path, n.content")
             while result.has_next():
                 row = result.get_next()
                 fp = row[0] or ""
@@ -804,9 +855,7 @@ class KuzuBackend:
             try:
                 conn.execute(f"MATCH (n:{table}) DETACH DELETE n")
             except Exception:
-                logger.debug(
-                    "delete_synthetic_nodes: failed for %s", table, exc_info=True
-                )
+                logger.debug("delete_synthetic_nodes: failed for %s", table, exc_info=True)
 
     def upsert_embeddings(self, embeddings: list[NodeEmbedding]) -> None:
         """Insert or update embeddings without wiping existing ones."""
@@ -818,13 +867,9 @@ class KuzuBackend:
                     parameters={"nid": emb.node_id, "vec": emb.embedding},
                 )
             except Exception:
-                logger.debug(
-                    "upsert_embeddings failed for %s", emb.node_id, exc_info=True
-                )
+                logger.debug("upsert_embeddings failed for %s", emb.node_id, exc_info=True)
 
-    def update_dead_flags(
-        self, dead_ids: set[str], alive_ids: set[str]
-    ) -> None:
+    def update_dead_flags(self, dead_ids: set[str], alive_ids: set[str]) -> None:
         """Set is_dead=True on *dead_ids* and is_dead=False on *alive_ids*."""
         conn = self._require_conn()
 
@@ -841,9 +886,7 @@ class KuzuBackend:
                         parameters={"ids": id_list, "val": value},
                     )
                 except Exception:
-                    logger.debug(
-                        "update_dead_flags failed for table %s", table, exc_info=True
-                    )
+                    logger.debug("update_dead_flags failed for table %s", table, exc_info=True)
 
         _batch_set(dead_ids, True)
         _batch_set(alive_ids, False)
@@ -946,14 +989,28 @@ class KuzuBackend:
 
         try:
             for table, nodes in by_table.items():
-                self._csv_copy(table, [
-                    [node.id, node.name, node.file_path, node.start_line,
-                     node.end_line, node.content, node.signature, node.language,
-                     node.class_name, node.is_dead, node.is_entry_point,
-                     node.is_exported, (node.properties or {}).get("cohesion"),
-                     _serialize_extra_props(node.properties)]
-                    for node in nodes
-                ])
+                self._csv_copy(
+                    table,
+                    [
+                        [
+                            node.id,
+                            node.name,
+                            node.file_path,
+                            node.start_line,
+                            node.end_line,
+                            node.content,
+                            node.signature,
+                            node.language,
+                            node.class_name,
+                            node.is_dead,
+                            node.is_entry_point,
+                            node.is_exported,
+                            (node.properties or {}).get("cohesion"),
+                            _serialize_extra_props(node.properties),
+                        ]
+                        for node in nodes
+                    ],
+                )
             return True
         except Exception:
             logger.debug("CSV bulk_load_nodes failed, falling back", exc_info=True)
@@ -979,16 +1036,23 @@ class KuzuBackend:
 
         try:
             for (src_table, dst_table), rels in by_pair.items():
-                self._csv_copy(f"CodeRelation_{src_table}_{dst_table}", [
-                    [rel.source, rel.target, rel.type.value,
-                     float((rel.properties or {}).get("confidence", 1.0)),
-                     str((rel.properties or {}).get("role", "")),
-                     int((rel.properties or {}).get("step_number", 0)),
-                     float((rel.properties or {}).get("strength", 0.0)),
-                     int((rel.properties or {}).get("co_changes", 0)),
-                     str((rel.properties or {}).get("symbols", ""))]
-                    for rel in rels
-                ])
+                self._csv_copy(
+                    f"CodeRelation_{src_table}_{dst_table}",
+                    [
+                        [
+                            rel.source,
+                            rel.target,
+                            rel.type.value,
+                            float((rel.properties or {}).get("confidence", 1.0)),
+                            str((rel.properties or {}).get("role", "")),
+                            int((rel.properties or {}).get("step_number", 0)),
+                            float((rel.properties or {}).get("strength", 0.0)),
+                            int((rel.properties or {}).get("co_changes", 0)),
+                            str((rel.properties or {}).get("symbols", "")),
+                        ]
+                        for rel in rels
+                    ],
+                )
             return True
         except Exception:
             logger.debug("CSV bulk_load_rels failed, falling back", exc_info=True)
@@ -1005,7 +1069,7 @@ class KuzuBackend:
             if not self._embeddings_clean:
                 current_ids = [emb.node_id for emb in embeddings]
                 for i in range(0, len(current_ids), 500):
-                    batch = current_ids[i:i + 500]
+                    batch = current_ids[i : i + 500]
                     try:
                         conn.execute(
                             "MATCH (e:Embedding) WHERE e.node_id IN $ids DETACH DELETE e",
@@ -1014,10 +1078,9 @@ class KuzuBackend:
                     except Exception:
                         pass
 
-            self._csv_copy("Embedding", [
-                [emb.node_id, json.dumps(emb.embedding)]
-                for emb in embeddings
-            ])
+            self._csv_copy(
+                "Embedding", [[emb.node_id, json.dumps(emb.embedding)] for emb in embeddings]
+            )
             self._embeddings_clean = False
             return True
         except Exception:
@@ -1043,7 +1106,7 @@ class KuzuBackend:
                 pass
 
         conn.execute(
-            f"CREATE NODE TABLE IF NOT EXISTS Embedding({_EMBEDDING_PROPERTIES})"
+            f"CREATE NODE TABLE IF NOT EXISTS Embedding({_embedding_properties(self._embedding_dimensions)})"
         )
 
         from_to_pairs: list[str] = []
@@ -1053,8 +1116,7 @@ class KuzuBackend:
 
         pairs_clause = ", ".join(from_to_pairs)
         rel_stmt = (
-            f"CREATE REL TABLE GROUP IF NOT EXISTS CodeRelation("
-            f"{pairs_clause}, {_REL_PROPERTIES})"
+            f"CREATE REL TABLE GROUP IF NOT EXISTS CodeRelation({pairs_clause}, {_REL_PROPERTIES})"
         )
         try:
             conn.execute(rel_stmt)
@@ -1161,9 +1223,7 @@ class KuzuBackend:
                 "Insert relationship failed: %s -> %s", rel.source, rel.target, exc_info=True
             )
 
-    def _query_nodes(
-        self, query: str, parameters: dict[str, Any] | None = None
-    ) -> list[GraphNode]:
+    def _query_nodes(self, query: str, parameters: dict[str, Any] | None = None) -> list[GraphNode]:
         """Execute a query returning ``n.*`` columns and convert to GraphNode list."""
         conn = self._require_conn()
         nodes: list[GraphNode] = []

--- a/src/axon/mcp/tools.py
+++ b/src/axon/mcp/tools.py
@@ -47,6 +47,7 @@ def _resolve_symbol(storage: StorageBackend, symbol: str) -> list:
             return results
     return storage.fts_search(symbol, limit=1)
 
+
 def handle_list_repos(registry_dir: Path | None = None) -> str:
     """List indexed repositories by scanning for .axon directories.
 
@@ -102,6 +103,7 @@ def handle_list_repos(registry_dir: Path | None = None) -> str:
         lines.append("")
 
     return "\n".join(lines)
+
 
 def _group_by_process(
     results: list,
@@ -190,6 +192,7 @@ def handle_query(storage: StorageBackend, query: str, limit: int = 20) -> str:
     groups = _group_by_process(results, storage)
     return _format_query_results(results, groups)
 
+
 def handle_context(storage: StorageBackend, symbol: str) -> str:
     """Provide a 360-degree view of a symbol.
 
@@ -253,12 +256,15 @@ def handle_context(storage: StorageBackend, symbol: str) -> str:
             lines.append(f"  -> {t.name}  {t.file_path}")
 
     escaped_id = _escape_cypher(node.id)
-    heritage_rows = storage.execute_raw(
-        f"MATCH (n)-[r:CodeRelation]->(parent) "
-        f"WHERE n.id = '{escaped_id}' "
-        f"AND r.rel_type IN ['extends', 'implements'] "
-        f"RETURN parent.name, parent.file_path, r.rel_type"
-    ) or []
+    heritage_rows = (
+        storage.execute_raw(
+            f"MATCH (n)-[r:CodeRelation]->(parent) "
+            f"WHERE n.id = '{escaped_id}' "
+            f"AND r.rel_type IN ['extends', 'implements'] "
+            f"RETURN parent.name, parent.file_path, r.rel_type"
+        )
+        or []
+    )
     if heritage_rows:
         lines.append(f"\nHeritage ({len(heritage_rows)}):")
         for row in heritage_rows:
@@ -269,12 +275,15 @@ def handle_context(storage: StorageBackend, symbol: str) -> str:
 
     if node.file_path:
         escaped_fp = _escape_cypher(node.file_path)
-        import_rows = storage.execute_raw(
-            f"MATCH (a:File)-[r:CodeRelation]->(b:File) "
-            f"WHERE b.file_path = '{escaped_fp}' "
-            f"AND r.rel_type = 'imports' "
-            f"RETURN a.file_path ORDER BY a.file_path"
-        ) or []
+        import_rows = (
+            storage.execute_raw(
+                f"MATCH (a:File)-[r:CodeRelation]->(b:File) "
+                f"WHERE b.file_path = '{escaped_fp}' "
+                f"AND r.rel_type = 'imports' "
+                f"RETURN a.file_path ORDER BY a.file_path"
+            )
+            or []
+        )
         if import_rows:
             importers = [r[0] for r in import_rows if r[0]]
             lines.append(f"\nImported by ({len(importers)}):")
@@ -284,6 +293,7 @@ def handle_context(storage: StorageBackend, symbol: str) -> str:
     lines.append("")
     lines.append("Next: Use impact() if planning changes to this symbol.")
     return "\n".join(lines)
+
 
 _DEPTH_LABELS: dict[int, str] = {
     1: "Direct callers (will break)",
@@ -318,9 +328,7 @@ def handle_impact(storage: StorageBackend, symbol: str, depth: int = 3) -> str:
     if not start_node:
         return f"Symbol '{symbol}' not found."
 
-    affected_with_depth = storage.traverse_with_depth(
-        start_node.id, depth, direction="callers"
-    )
+    affected_with_depth = storage.traverse_with_depth(start_node.id, depth, direction="callers")
     if not affected_with_depth:
         return f"No upstream callers found for '{symbol}'."
 
@@ -346,14 +354,14 @@ def handle_impact(storage: StorageBackend, symbol: str, depth: int = 3) -> str:
             conf = conf_lookup.get(node.id)
             tag = f"  (confidence: {conf:.2f})" if conf is not None else ""
             lines.append(
-                f"  {counter}. {node.name} ({label}) -- "
-                f"{node.file_path}:{node.start_line}{tag}"
+                f"  {counter}. {node.name} ({label}) -- {node.file_path}:{node.start_line}{tag}"
             )
             counter += 1
 
     lines.append("")
     lines.append("Tip: Review each affected symbol before making changes.")
     return "\n".join(lines)
+
 
 def handle_dead_code(storage: StorageBackend) -> str:
     """List all symbols marked as dead code.
@@ -368,6 +376,7 @@ def handle_dead_code(storage: StorageBackend) -> str:
         Formatted list of dead code symbols grouped by file.
     """
     return get_dead_code_list(storage)
+
 
 _DIFF_FILE_PATTERN = re.compile(r"^diff --git a/(.+?) b/(.+?)$", re.MULTILINE)
 _DIFF_HUNK_PATTERN = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", re.MULTILINE)
@@ -429,11 +438,14 @@ def handle_detect_changes(storage: StorageBackend, diff: str) -> str:
             lines.append("")
             continue
 
-        rows = storage.execute_raw(
-            f"MATCH (n) WHERE n.file_path = '{_escape_cypher(file_path)}' "
-            f"AND n.start_line > 0 "
-            f"RETURN n.id, n.name, n.file_path, n.start_line, n.end_line"
-        ) or []
+        rows = (
+            storage.execute_raw(
+                f"MATCH (n) WHERE n.file_path = '{_escape_cypher(file_path)}' "
+                f"AND n.start_line > 0 "
+                f"RETURN n.id, n.name, n.file_path, n.start_line, n.end_line"
+            )
+            or []
+        )
         for row in rows:
             node_id = row[0] or ""
             name = row[1] or ""
@@ -458,6 +470,7 @@ def handle_detect_changes(storage: StorageBackend, diff: str) -> str:
     lines.append("")
     lines.append("Next: Use impact() on affected symbols to see downstream effects.")
     return "\n".join(lines)
+
 
 def handle_cypher(storage: StorageBackend, query: str) -> str:
     """Execute a raw Cypher query and return formatted results.
@@ -497,9 +510,7 @@ def handle_cypher(storage: StorageBackend, query: str) -> str:
     return "\n".join(lines)
 
 
-def handle_coupling(
-    storage: StorageBackend, file_path: str, min_strength: float = 0.3
-) -> str:
+def handle_coupling(storage: StorageBackend, file_path: str, min_strength: float = 0.3) -> str:
     """Query temporal coupling for a file and flag hidden dependencies."""
     if not file_path or not file_path.strip():
         return "Error: 'file_path' parameter is required and cannot be empty."
@@ -509,23 +520,29 @@ def handle_coupling(
         return "Error: file path contains unsafe characters."
 
     escaped = _escape_cypher(file_path)
-    rows = storage.execute_raw(
-        f"MATCH (a:File)-[r:COUPLED_WITH]-(b:File) "
-        f"WHERE a.file_path = '{escaped}' "
-        f"RETURN b.file_path, r.strength, r.co_changes "
-        f"ORDER BY r.strength DESC"
-    ) or []
+    rows = (
+        storage.execute_raw(
+            f"MATCH (a:File)-[r:CodeRelation]-(b:File) "
+            f"WHERE r.rel_type = 'coupled_with' AND a.file_path = '{escaped}' "
+            f"RETURN b.file_path, r.strength, r.co_changes "
+            f"ORDER BY r.strength DESC"
+        )
+        or []
+    )
 
     rows = [r for r in rows if (r[1] or 0) >= min_strength]
 
     if not rows:
         return f"No temporal coupling found for '{file_path}' (min strength: {min_strength})."
 
-    import_rows = storage.execute_raw(
-        f"MATCH (a:File)-[r:CodeRelation]->(b:File) "
-        f"WHERE a.file_path = '{escaped}' AND r.rel_type = 'imports' "
-        f"RETURN b.file_path"
-    ) or []
+    import_rows = (
+        storage.execute_raw(
+            f"MATCH (a:File)-[r:CodeRelation]->(b:File) "
+            f"WHERE a.file_path = '{escaped}' AND r.rel_type = 'imports' "
+            f"RETURN b.file_path"
+        )
+        or []
+    )
     imported_files = {r[0] for r in import_rows}
 
     lines = [f"Temporal coupling for: {file_path}"]
@@ -634,19 +651,20 @@ def handle_call_path(
     return header + "\n\n" + "\n".join(lines)
 
 
-def handle_communities(
-    storage: StorageBackend, community: str | None = None
-) -> str:
+def handle_communities(storage: StorageBackend, community: str | None = None) -> str:
     """List communities or drill into a specific one."""
     if community:
         escaped = _escape_cypher(community)
-        rows = storage.execute_raw(
-            f"MATCH (n)-[:MEMBER_OF]->(c:Community) "
-            f"WHERE c.name = '{escaped}' "
-            f"RETURN n.name, label(n), n.file_path, n.start_line, "
-            f"n.is_entry_point, n.is_exported "
-            f"ORDER BY n.file_path, n.start_line"
-        ) or []
+        rows = (
+            storage.execute_raw(
+                f"MATCH (n)-[:CodeRelation]->(c:Community) "
+                f"WHERE c.name = '{escaped}' "
+                f"RETURN n.name, label(n), n.file_path, n.start_line, "
+                f"n.is_entry_point, n.is_exported "
+                f"ORDER BY n.file_path, n.start_line"
+            )
+            or []
+        )
 
         if not rows:
             return f"Community '{community}' not found or has no members."
@@ -671,11 +689,14 @@ def handle_communities(
 
         return "\n".join(lines)
 
-    rows = storage.execute_raw(
-        "MATCH (c:Community) "
-        "RETURN c.name, c.cohesion, c.properties_json "
-        "ORDER BY c.cohesion DESC"
-    ) or []
+    rows = (
+        storage.execute_raw(
+            "MATCH (c:Community) "
+            "RETURN c.name, c.cohesion, c.properties_json "
+            "ORDER BY c.cohesion DESC"
+        )
+        or []
+    )
 
     if not rows:
         return "No communities detected. Run indexing with community detection enabled."
@@ -693,12 +714,15 @@ def handle_communities(
         symbol_count = props.get("symbol_count", "?")
         lines.append(f"  {i}. {name}  (cohesion: {cohesion:.2f}, {symbol_count} symbols)")
 
-    cross_procs = storage.execute_raw(
-        "MATCH (n)-[:STEP_IN_PROCESS]->(p:Process), (n)-[:MEMBER_OF]->(c:Community) "
-        "WITH p.name AS proc, collect(DISTINCT c.name) AS comms "
-        "WHERE size(comms) > 1 "
-        "RETURN proc, comms"
-    ) or []
+    cross_procs = (
+        storage.execute_raw(
+            "MATCH (n)-[:CodeRelation]->(p:Process), (n)-[:CodeRelation]->(c:Community) "
+            "WITH p.name AS proc, collect(DISTINCT c.name) AS comms "
+            "WHERE size(comms) > 1 "
+            "RETURN proc, comms"
+        )
+        or []
+    )
 
     if cross_procs:
         lines.append("")
@@ -746,11 +770,12 @@ def handle_explain(storage: StorageBackend, symbol: str) -> str:
         lines.append(f"Signature: {node.signature}")
 
     escaped_id = _escape_cypher(node.id)
-    comm_rows = storage.execute_raw(
-        f"MATCH (n)-[:MEMBER_OF]->(c:Community) "
-        f"WHERE n.id = '{escaped_id}' "
-        f"RETURN c.name"
-    ) or []
+    comm_rows = (
+        storage.execute_raw(
+            f"MATCH (n)-[:CodeRelation]->(c:Community) WHERE n.id = '{escaped_id}' RETURN c.name"
+        )
+        or []
+    )
     if comm_rows:
         comm_name = comm_rows[0][0] or "?"
         lines.append(f"Community: {comm_name}")
@@ -774,11 +799,12 @@ def handle_explain(storage: StorageBackend, symbol: str) -> str:
     else:
         lines.append("Calls: nothing (leaf)")
 
-    proc_rows = storage.execute_raw(
-        f"MATCH (n)-[:STEP_IN_PROCESS]->(p:Process) "
-        f"WHERE n.id = '{escaped_id}' "
-        f"RETURN p.name"
-    ) or []
+    proc_rows = (
+        storage.execute_raw(
+            f"MATCH (n)-[:CodeRelation]->(p:Process) WHERE n.id = '{escaped_id}' RETURN p.name"
+        )
+        or []
+    )
     if proc_rows:
         lines.append("")
         lines.append("Process flows through this symbol:")
@@ -807,11 +833,14 @@ def handle_review_risk(storage: StorageBackend, diff: str) -> str:
         if not _SAFE_PATH.match(file_path):
             continue
         escaped = _escape_cypher(file_path)
-        rows = storage.execute_raw(
-            f"MATCH (n) WHERE n.file_path = '{escaped}' "
-            f"AND n.start_line > 0 "
-            f"RETURN n.id, n.name, n.file_path, n.start_line, n.end_line"
-        ) or []
+        rows = (
+            storage.execute_raw(
+                f"MATCH (n) WHERE n.file_path = '{escaped}' "
+                f"AND n.start_line > 0 "
+                f"RETURN n.id, n.name, n.file_path, n.start_line, n.end_line"
+            )
+            or []
+        )
 
         for row in rows:
             node_id = row[0] or ""
@@ -840,11 +869,15 @@ def handle_review_risk(storage: StorageBackend, diff: str) -> str:
         if not _SAFE_PATH.match(file_path):
             continue
         escaped = _escape_cypher(file_path)
-        coupling_rows = storage.execute_raw(
-            f"MATCH (a:File)-[r:COUPLED_WITH]-(b:File) "
-            f"WHERE a.file_path = '{escaped}' AND r.strength >= 0.5 "
-            f"RETURN b.file_path, r.strength"
-        ) or []
+        coupling_rows = (
+            storage.execute_raw(
+                f"MATCH (a:File)-[r:CodeRelation]-(b:File) "
+                f"WHERE r.rel_type = 'coupled_with' "
+                f"AND a.file_path = '{escaped}' AND r.strength >= 0.5 "
+                f"RETURN b.file_path, r.strength"
+            )
+            or []
+        )
         for row in coupling_rows:
             coupled_file = row[0] or ""
             strength = row[1] or 0.0
@@ -854,10 +887,12 @@ def handle_review_risk(storage: StorageBackend, diff: str) -> str:
     communities_touched: set[str] = set()
     for name, label, file_path, _ in all_affected_symbols:
         escaped = _escape_cypher(f"{label.lower()}:{file_path}:{name}")
-        comm_rows = storage.execute_raw(
-            f"MATCH (n)-[:MEMBER_OF]->(c:Community) "
-            f"WHERE n.id = '{escaped}' RETURN c.name"
-        ) or []
+        comm_rows = (
+            storage.execute_raw(
+                f"MATCH (n)-[:CodeRelation]->(c:Community) WHERE n.id = '{escaped}' RETURN c.name"
+            )
+            or []
+        )
         for row in comm_rows:
             if row[0]:
                 communities_touched.add(row[0])
@@ -915,41 +950,59 @@ def handle_file_context(storage: StorageBackend, file_path: str) -> str:
 
     escaped = _escape_cypher(file_path)
 
-    sym_rows = storage.execute_raw(
-        f"MATCH (n) WHERE n.file_path = '{escaped}' AND n.start_line > 0 "
-        f"RETURN n.name, label(n), n.start_line, n.is_dead, n.is_entry_point, n.is_exported "
-        f"ORDER BY n.start_line"
-    ) or []
+    sym_rows = (
+        storage.execute_raw(
+            f"MATCH (n) WHERE n.file_path = '{escaped}' AND n.start_line > 0 "
+            f"RETURN n.name, label(n), n.start_line, n.is_dead, n.is_entry_point, n.is_exported "
+            f"ORDER BY n.start_line"
+        )
+        or []
+    )
 
-    imports_out = storage.execute_raw(
-        f"MATCH (a:File)-[r:CodeRelation]->(b:File) "
-        f"WHERE a.file_path = '{escaped}' AND r.rel_type = 'imports' "
-        f"RETURN b.file_path ORDER BY b.file_path"
-    ) or []
+    imports_out = (
+        storage.execute_raw(
+            f"MATCH (a:File)-[r:CodeRelation]->(b:File) "
+            f"WHERE a.file_path = '{escaped}' AND r.rel_type = 'imports' "
+            f"RETURN b.file_path ORDER BY b.file_path"
+        )
+        or []
+    )
 
-    imports_in = storage.execute_raw(
-        f"MATCH (a:File)-[r:CodeRelation]->(b:File) "
-        f"WHERE b.file_path = '{escaped}' AND r.rel_type = 'imports' "
-        f"RETURN a.file_path ORDER BY a.file_path"
-    ) or []
+    imports_in = (
+        storage.execute_raw(
+            f"MATCH (a:File)-[r:CodeRelation]->(b:File) "
+            f"WHERE b.file_path = '{escaped}' AND r.rel_type = 'imports' "
+            f"RETURN a.file_path ORDER BY a.file_path"
+        )
+        or []
+    )
 
-    coupling_rows = storage.execute_raw(
-        f"MATCH (a:File)-[r:COUPLED_WITH]-(b:File) "
-        f"WHERE a.file_path = '{escaped}' "
-        f"RETURN b.file_path, r.strength, r.co_changes "
-        f"ORDER BY r.strength DESC LIMIT 5"
-    ) or []
+    coupling_rows = (
+        storage.execute_raw(
+            f"MATCH (a:File)-[r:CodeRelation]-(b:File) "
+            f"WHERE r.rel_type = 'coupled_with' AND a.file_path = '{escaped}' "
+            f"RETURN b.file_path, r.strength, r.co_changes "
+            f"ORDER BY r.strength DESC LIMIT 5"
+        )
+        or []
+    )
 
-    dead_rows = storage.execute_raw(
-        f"MATCH (n) WHERE n.is_dead = true AND n.file_path = '{escaped}' "
-        f"RETURN n.name, n.start_line, label(n)"
-    ) or []
+    dead_rows = (
+        storage.execute_raw(
+            f"MATCH (n) WHERE n.is_dead = true AND n.file_path = '{escaped}' "
+            f"RETURN n.name, n.start_line, label(n)"
+        )
+        or []
+    )
 
-    comm_rows = storage.execute_raw(
-        f"MATCH (n)-[r:CodeRelation]->(c:Community) "
-        f"WHERE n.file_path = '{escaped}' AND r.rel_type = 'member_of' "
-        f"RETURN c.name, count(n) ORDER BY count(n) DESC"
-    ) or []
+    comm_rows = (
+        storage.execute_raw(
+            f"MATCH (n)-[r:CodeRelation]->(c:Community) "
+            f"WHERE n.file_path = '{escaped}' AND r.rel_type = 'member_of' "
+            f"RETURN c.name, count(n) ORDER BY count(n) DESC"
+        )
+        or []
+    )
 
     if not sym_rows and not imports_out and not imports_in:
         return f"No data found for file '{file_path}'. Is it indexed?"
@@ -1028,11 +1081,7 @@ def handle_cycles(storage: StorageBackend, min_size: int = 2) -> str:
 
     sccs = ig_graph.connected_components(mode="strong")
 
-    cycles = [
-        list(component)
-        for component in sccs
-        if len(component) >= min_size
-    ]
+    cycles = [list(component) for component in sccs if len(component) >= min_size]
 
     if not cycles:
         return "No circular dependencies detected."
@@ -1052,10 +1101,7 @@ def handle_cycles(storage: StorageBackend, min_size: int = 2) -> str:
         lines.append(f"\nCycle {i} ({len(nodes)} symbols){size_label}:")
         for node in nodes:
             label = node.label.value.title() if node.label else "Unknown"
-            lines.append(
-                f"  - {node.name} ({label}) — "
-                f"{node.file_path}:{node.start_line}"
-            )
+            lines.append(f"  - {node.name} ({label}) — {node.file_path}:{node.start_line}")
 
     return "\n".join(lines)
 
@@ -1074,11 +1120,14 @@ def handle_test_impact(
             if not _SAFE_PATH.match(file_path):
                 continue
             escaped = _escape_cypher(file_path)
-            rows = storage.execute_raw(
-                f"MATCH (n) WHERE n.file_path = '{escaped}' "
-                f"AND n.start_line > 0 "
-                f"RETURN n.id, n.name, n.start_line, n.end_line"
-            ) or []
+            rows = (
+                storage.execute_raw(
+                    f"MATCH (n) WHERE n.file_path = '{escaped}' "
+                    f"AND n.start_line > 0 "
+                    f"RETURN n.id, n.name, n.start_line, n.end_line"
+                )
+                or []
+            )
             for row in rows:
                 node_id = row[0] or ""
                 name = row[1] or ""
@@ -1107,9 +1156,7 @@ def handle_test_impact(
     for sym_id, sym_name in changed_symbol_ids:
         for caller, depth in storage.traverse_with_depth(sym_id, 4, direction="callers"):
             if _is_test_file(caller.file_path):
-                test_hits.setdefault(caller.file_path, []).append(
-                    (caller.name, sym_name, depth)
-                )
+                test_hits.setdefault(caller.file_path, []).append((caller.name, sym_name, depth))
 
     if not test_hits:
         return (

--- a/tests/core/test_embedder.py
+++ b/tests/core/test_embedder.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import json
+import os
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 
 from axon.core.embeddings.embedder import (
-    EMBEDDABLE_LABELS,
     _DEFAULT_BATCH_SIZE,
     _DEFAULT_DIMENSIONS,
     _DEFAULT_MODEL,
+    EMBEDDABLE_LABELS,
     _get_model,
+    _HttpEmbedder,
     embed_graph,
     embed_nodes,
     embed_query,
@@ -154,7 +157,9 @@ class TestEmbeddableLabels:
 
 class TestEmbedGraphBasic:
     @patch("fastembed.TextEmbedding")
-    def test_returns_node_embeddings(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
+    def test_returns_node_embeddings(
+        self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph
+    ) -> None:
         mock_model = MagicMock()
         mock_model.passage_embed.return_value = iter(
             [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
@@ -220,9 +225,7 @@ class TestEmbedGraphBasic:
 
 class TestEmbedGraphFiltering:
     @patch("fastembed.TextEmbedding")
-    def test_skips_folder_nodes(
-        self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph
-    ) -> None:
+    def test_skips_folder_nodes(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
         mock_model = MagicMock()
         mock_model.passage_embed.return_value = iter(
             [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
@@ -295,12 +298,8 @@ class TestEmbedGraphEmpty:
         mock_te_cls.return_value = mock_model
 
         graph = KnowledgeGraph()
-        graph.add_node(
-            GraphNode(id="folder::src", label=NodeLabel.FOLDER, name="src")
-        )
-        graph.add_node(
-            GraphNode(id="community::auth", label=NodeLabel.COMMUNITY, name="auth")
-        )
+        graph.add_node(GraphNode(id="folder::src", label=NodeLabel.FOLDER, name="src"))
+        graph.add_node(GraphNode(id="community::auth", label=NodeLabel.COMMUNITY, name="auth"))
 
         results = embed_graph(graph)
 
@@ -394,7 +393,11 @@ class TestEmbedGraphTextGeneration:
 
         # The texts list passed to model.passage_embed should contain both texts
         embed_call_args = mock_model.passage_embed.call_args
-        texts_arg = embed_call_args.args[0] if embed_call_args.args else embed_call_args.kwargs.get("documents", [])
+        texts_arg = (
+            embed_call_args.args[0]
+            if embed_call_args.args
+            else embed_call_args.kwargs.get("documents", [])
+        )
         assert "text for foo" in texts_arg
         assert "text for Bar" in texts_arg
 
@@ -427,7 +430,9 @@ class TestEmbedGraphBatchProcessing:
         assert all(len(r.embedding) == EMBEDDING_DIMENSIONS for r in results)
 
     @patch("fastembed.TextEmbedding")
-    def test_default_batch_size_is_32(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
+    def test_default_batch_size_is_32(
+        self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph
+    ) -> None:
         mock_model = MagicMock()
         mock_model.passage_embed.return_value = iter(
             [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
@@ -487,29 +492,35 @@ def _make_incremental_graph() -> KnowledgeGraph:
     graph = KnowledgeGraph()
     fn_a = GraphNode(
         id=generate_id(NodeLabel.FUNCTION, "src/a.py", "func_a"),
-        label=NodeLabel.FUNCTION, name="func_a", file_path="src/a.py",
+        label=NodeLabel.FUNCTION,
+        name="func_a",
+        file_path="src/a.py",
         signature="def func_a():",
     )
     fn_b = GraphNode(
         id=generate_id(NodeLabel.FUNCTION, "src/b.py", "func_b"),
-        label=NodeLabel.FUNCTION, name="func_b", file_path="src/b.py",
+        label=NodeLabel.FUNCTION,
+        name="func_b",
+        file_path="src/b.py",
         signature="def func_b():",
     )
     graph.add_node(fn_a)
     graph.add_node(fn_b)
-    graph.add_relationship(GraphRelationship(
-        id=f"calls:{fn_a.id}->{fn_b.id}",
-        type=RelType.CALLS, source=fn_a.id, target=fn_b.id,
-    ))
+    graph.add_relationship(
+        GraphRelationship(
+            id=f"calls:{fn_a.id}->{fn_b.id}",
+            type=RelType.CALLS,
+            source=fn_a.id,
+            target=fn_b.id,
+        )
+    )
     return graph
 
 
 class TestEmbeddingAlignment:
     @patch("axon.core.embeddings.embedder.generate_text")
     @patch("fastembed.TextEmbedding")
-    def test_embedding_alignment(
-        self, mock_te_cls: MagicMock, mock_gen_text: MagicMock
-    ) -> None:
+    def test_embedding_alignment(self, mock_te_cls: MagicMock, mock_gen_text: MagicMock) -> None:
         graph = KnowledgeGraph()
         node_a = GraphNode(
             id="function:src/a.py:func_a",
@@ -575,7 +586,9 @@ class TestEmbedNodes:
         graph = KnowledgeGraph()
         folder = GraphNode(
             id=generate_id(NodeLabel.FOLDER, "src", "src"),
-            label=NodeLabel.FOLDER, name="src", file_path="src",
+            label=NodeLabel.FOLDER,
+            name="src",
+            file_path="src",
         )
         graph.add_node(folder)
         results = embed_nodes(graph, {folder.id})
@@ -623,3 +636,77 @@ class TestEmbedNodes:
         # After Matryoshka truncation, we get first 384 dims of the 768d vector
         expected = _vec768([1.0, 2.0, 3.0])[:384].tolist()
         assert results[0].embedding == pytest.approx(expected)
+
+
+class _FakeUrlOpenResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode()
+
+    def __enter__(self) -> "_FakeUrlOpenResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class TestRemoteHttpEmbedder:
+    def test_http_embedder_uses_openai_compatible_endpoint(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "AXON_EMBEDDING_BASE_URL": "http://example.test/v1",
+                "AXON_EMBEDDING_MODEL": "BAAI/bge-large-en-v1.5",
+                "AXON_EMBEDDING_API_KEY": "secret",
+            },
+            clear=False,
+        ):
+            import importlib
+
+            import axon.core.embeddings.embedder as embedder_module
+
+            embedder = importlib.reload(embedder_module)
+            try:
+                model = embedder._get_model(embedder._DEFAULT_MODEL)
+                assert isinstance(model, embedder._HttpEmbedder)
+
+                payload = {
+                    "data": [
+                        {"index": 0, "embedding": [0.5] * 1024},
+                    ]
+                }
+                with patch(
+                    "urllib.request.urlopen", return_value=_FakeUrlOpenResponse(payload)
+                ) as mock_urlopen:
+                    result = embedder.embed_query("test query")
+
+                assert result is not None
+                assert len(result) == EMBEDDING_DIMENSIONS
+                mock_urlopen.assert_called_once()
+            finally:
+                embedder._get_model.cache_clear()
+                importlib.reload(embedder_module)
+
+    def test_http_embedder_rejects_bad_indexes(self) -> None:
+        embedder = _HttpEmbedder("http://example.test/v1", "BAAI/bge-large-en-v1.5")
+        payload = {
+            "data": [
+                {"index": 1, "embedding": [0.1, 0.2, 0.3]},
+            ]
+        }
+        with patch("urllib.request.urlopen", return_value=_FakeUrlOpenResponse(payload)):
+            with pytest.raises(ValueError, match="indexes mismatch"):
+                list(embedder.passage_embed(["hello"], batch_size=1))
+
+    def test_http_embedder_rejects_non_finite_values(self) -> None:
+        embedder = _HttpEmbedder("http://example.test/v1", "BAAI/bge-large-en-v1.5")
+        payload = {
+            "data": [
+                {"index": 0, "embedding": [0.1, float("nan"), 0.3]},
+            ]
+        }
+        with patch("urllib.request.urlopen", return_value=_FakeUrlOpenResponse(payload)):
+            with pytest.raises(ValueError, match="non-finite"):
+                list(embedder.passage_embed(["hello"], batch_size=1))

--- a/tests/core/test_embedder.py
+++ b/tests/core/test_embedder.py
@@ -20,7 +20,7 @@ from axon.core.embeddings.embedder import (
 )
 from axon.core.graph.graph import KnowledgeGraph
 from axon.core.graph.model import GraphNode, GraphRelationship, NodeLabel, RelType, generate_id
-from axon.core.storage.base import EMBEDDING_DIMENSIONS, NodeEmbedding
+from axon.core.storage.base import EMBEDDING_DIMENSIONS, NodeEmbedding, get_embedding_dimensions
 
 
 def _vec768(base: list[float] | None = None) -> np.ndarray:
@@ -127,10 +127,37 @@ class TestModelDefaults:
         assert "nomic" in _DEFAULT_MODEL
 
     def test_default_dimensions(self) -> None:
-        assert _DEFAULT_DIMENSIONS == 384
+        assert _DEFAULT_DIMENSIONS == EMBEDDING_DIMENSIONS
 
     def test_default_batch_size(self) -> None:
         assert _DEFAULT_BATCH_SIZE == 32
+
+
+class TestEmbeddingDimensions:
+    def test_remote_bge_large_dimensions_are_inferred(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "AXON_EMBEDDING_BASE_URL": "http://example.test/v1",
+                "AXON_EMBEDDING_MODEL": "BAAI/bge-large-en-v1.5",
+            },
+            clear=False,
+        ):
+            _get_model.cache_clear()
+            assert get_embedding_dimensions() == 1024
+
+    def test_explicit_dimension_override_wins(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "AXON_EMBEDDING_BASE_URL": "http://example.test/v1",
+                "AXON_EMBEDDING_MODEL": "BAAI/bge-large-en-v1.5",
+                "AXON_EMBEDDING_DIMENSIONS": "768",
+            },
+            clear=False,
+        ):
+            _get_model.cache_clear()
+            assert get_embedding_dimensions() == 768
 
 
 class TestEmbeddableLabels:
@@ -683,7 +710,8 @@ class TestRemoteHttpEmbedder:
                     result = embedder.embed_query("test query")
 
                 assert result is not None
-                assert len(result) == EMBEDDING_DIMENSIONS
+                assert len(result) == 1024
+                assert get_embedding_dimensions() == 1024
                 mock_urlopen.assert_called_once()
             finally:
                 embedder._get_model.cache_clear()

--- a/tests/core/test_embedding_migration.py
+++ b/tests/core/test_embedding_migration.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
-import pytest
-
-from axon.core.embeddings.embedder import _DEFAULT_MODEL
+from axon.core.embeddings.embedder import _DEFAULT_MODEL, get_effective_embedding_model_name
 from axon.core.ingestion.watcher import ensure_current_embeddings
+from axon.core.storage.base import get_embedding_dimensions
 
 
 def test_needs_reembed_model_mismatch() -> None:
@@ -20,39 +19,67 @@ def test_needs_reembed_missing_key() -> None:
 
 
 def test_no_reembed_when_matching() -> None:
-    meta = {"embedding_model": _DEFAULT_MODEL}
+    meta = {"embedding_model": _DEFAULT_MODEL, "embedding_dimensions": 384}
     assert meta.get("embedding_model") == _DEFAULT_MODEL
+    assert meta.get("embedding_dimensions") == 384
 
 
 def test_ensure_current_embeddings_reembeds_and_updates_meta(tmp_path) -> None:
+    get_embedding_dimensions.cache_clear()
     repo_path = tmp_path
     axon_dir = repo_path / ".axon"
     axon_dir.mkdir()
     meta_path = axon_dir / "meta.json"
     meta_path.write_text(
-        json.dumps({"embedding_model": "BAAI/bge-small-en-v1.5"}) + "\n",
+        json.dumps({"embedding_model": "BAAI/bge-small-en-v1.5", "embedding_dimensions": 384})
+        + "\n",
         encoding="utf-8",
     )
 
     storage = MagicMock()
     storage.load_graph.return_value = object()
 
-    with patch("axon.core.ingestion.watcher.embed_graph", return_value={"node-1": [0.1, 0.2]}):
+    with patch("axon.core.ingestion.watcher.embed_graph", return_value=[MagicMock()]):
         migrated = ensure_current_embeddings(storage, repo_path)
 
     assert migrated is True
     storage.load_graph.assert_called_once_with()
-    storage.store_embeddings.assert_called_once_with({"node-1": [0.1, 0.2]})
+    storage.store_embeddings.assert_called_once()
     updated_meta = json.loads(meta_path.read_text(encoding="utf-8"))
-    assert updated_meta["embedding_model"] == _DEFAULT_MODEL
+    assert updated_meta["embedding_model"] == get_effective_embedding_model_name()
+    assert updated_meta["embedding_dimensions"] == 384
 
 
-def test_ensure_current_embeddings_noop_when_model_matches(tmp_path) -> None:
+def test_ensure_current_embeddings_reembeds_when_dimensions_change(tmp_path) -> None:
+    get_embedding_dimensions.cache_clear()
     repo_path = tmp_path
     axon_dir = repo_path / ".axon"
     axon_dir.mkdir()
     (axon_dir / "meta.json").write_text(
-        json.dumps({"embedding_model": _DEFAULT_MODEL}) + "\n",
+        json.dumps({"embedding_model": _DEFAULT_MODEL, "embedding_dimensions": 384}) + "\n",
+        encoding="utf-8",
+    )
+
+    storage = MagicMock()
+    storage.load_graph.return_value = object()
+
+    with patch.dict("os.environ", {"AXON_EMBEDDING_DIMENSIONS": "1024"}, clear=False):
+        get_embedding_dimensions.cache_clear()
+        with patch("axon.core.ingestion.watcher.embed_graph", return_value=[MagicMock()]):
+            migrated = ensure_current_embeddings(storage, repo_path)
+
+    assert migrated is True
+    storage.load_graph.assert_called_once_with()
+    storage.store_embeddings.assert_called_once()
+
+
+def test_ensure_current_embeddings_noop_when_model_matches(tmp_path) -> None:
+    get_embedding_dimensions.cache_clear()
+    repo_path = tmp_path
+    axon_dir = repo_path / ".axon"
+    axon_dir.mkdir()
+    (axon_dir / "meta.json").write_text(
+        json.dumps({"embedding_model": _DEFAULT_MODEL, "embedding_dimensions": 384}) + "\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
Rebased PR #58 onto latest upstream main and extended it to fully support the configured remote embedding provider end-to-end.

This now:
- uses the configured HTTP embedding provider for Axon
- records the effective embedding model and dimensions in .axon/meta.json
- updates Kuzu embedding schema and vector casts to match configured dimensions
- re-embeds when model or dimensions change
- refreshes embedding config correctly in long-lived processes

Verified with:
- Axon tests passing locally
- kg2 reindexed successfully with BAAI/bge-large-en-v1.5 at 1024 dimensions
- pi-ult reindexed successfully with the same provider/model/dimensions

Operational note:
- long reindexes should be launched as managed background jobs
- query/tool usage still goes through the Axon MCP/tool path
