### PR TITLE
Watch not honoring .gitignore #59

### DIFF
--- a/src/axon/core/ingestion/watcher.py
+++ b/src/axon/core/ingestion/watcher.py
@@ -63,6 +63,31 @@ def _get_head_sha(repo_path: Path) -> str | None:
     return None
 
 
+def _make_watch_filter(
+    repo_path: Path,
+    gitignore_patterns: list[str] | None,
+):
+    """Return a watchfiles-compatible filter that respects .gitignore.
+
+    Wraps :class:`watchfiles.DefaultFilter` and additionally skips any path
+    that :func:`~axon.config.ignore.should_ignore` would reject, so the watcher
+    never surfaces events from build artefact directories, ``node_modules``,
+    ``mysql_data``, or any other gitignored path.
+    """
+    default_filter = watchfiles.DefaultFilter()
+
+    def watch_filter(change_type: watchfiles.Change, path_str: str) -> bool:
+        if not default_filter(change_type, path_str):
+            return False
+        try:
+            relative = str(Path(path_str).relative_to(repo_path))
+        except ValueError:
+            return True  # outside repo_path — leave the decision to watchfiles
+        return not should_ignore(relative, gitignore_patterns)
+
+    return watch_filter
+
+
 def _reindex_files(
     changed_paths: list[Path],
     repo_path: Path,
@@ -80,6 +105,8 @@ def _reindex_files(
         if not abs_path.is_file():
             try:
                 relative = str(abs_path.relative_to(repo_path))
+                if should_ignore(relative, gitignore_patterns):
+                    continue
                 storage.remove_nodes_by_file(relative)
                 reindexed_paths.add(relative)
             except (ValueError, OSError):
@@ -232,6 +259,7 @@ async def watch_repo(
 
     async for changes in watchfiles.awatch(
         repo_path,
+        watch_filter=_make_watch_filter(repo_path, gitignore),
         rust_timeout=_POLL_INTERVAL_MS,
         yield_on_timeout=True,
         stop_event=stop_event,

--- a/tests/core/test_watcher.py
+++ b/tests/core/test_watcher.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import watchfiles
 
 from axon.core.graph.graph import KnowledgeGraph
 from axon.core.graph.model import GraphNode, GraphRelationship, NodeLabel, RelType
@@ -13,6 +14,7 @@ from axon.core.ingestion.walker import FileEntry, read_file
 from axon.core.ingestion.watcher import (
     _compute_dirty_node_ids,
     _get_head_sha,
+    _make_watch_filter,
     _reindex_files,
     _run_incremental_global_phases,
 )
@@ -296,6 +298,19 @@ class TestWatcherReindexFiles:
         # Returns 1: the deleted file was processed (nodes removed from storage).
         assert count == 1
 
+    def test_skips_deleted_files_in_ignored_dirs(
+        self, tmp_repo: Path, storage: KuzuBackend
+    ) -> None:
+        run_pipeline(tmp_repo, storage)
+
+        # A file that never existed in the index (lives in an ignored directory).
+        ignored_deleted = tmp_repo / "build" / "output.py"
+
+        count, _paths = _reindex_files([ignored_deleted], tmp_repo, storage)
+
+        # The ignored path should not be processed at all.
+        assert count == 0
+
     def test_handles_multiple_files(
         self, tmp_repo: Path, storage: KuzuBackend
     ) -> None:
@@ -318,6 +333,46 @@ class TestWatcherReindexFiles:
         )
 
         assert count == 2
+
+
+class TestWatchFilter:
+    """Tests for _make_watch_filter — the gitignore-aware watchfiles filter."""
+
+    def test_allows_regular_source_file(self, tmp_repo: Path) -> None:
+        watch_filter = _make_watch_filter(tmp_repo, None)
+        src_file = str(tmp_repo / "src" / "app.py")
+        assert watch_filter(watchfiles.Change.modified, src_file) is True
+
+    def test_blocks_default_ignored_directory(self, tmp_repo: Path) -> None:
+        watch_filter = _make_watch_filter(tmp_repo, None)
+        cached = str(tmp_repo / "__pycache__" / "module.cpython-311.pyc")
+        assert watch_filter(watchfiles.Change.added, cached) is False
+
+    def test_blocks_gitignore_pattern(self, tmp_repo: Path) -> None:
+        # Write a .gitignore that excludes "build/" directory.
+        (tmp_repo / ".gitignore").write_text("build/\n", encoding="utf-8")
+        gitignore_patterns = ["build/"]
+        watch_filter = _make_watch_filter(tmp_repo, gitignore_patterns)
+        build_file = str(tmp_repo / "build" / "output.py")
+        assert watch_filter(watchfiles.Change.added, build_file) is False
+
+    def test_allows_non_ignored_file_with_gitignore(self, tmp_repo: Path) -> None:
+        gitignore_patterns = ["build/", "dist/", "*.log"]
+        watch_filter = _make_watch_filter(tmp_repo, gitignore_patterns)
+        normal_file = str(tmp_repo / "src" / "main.py")
+        assert watch_filter(watchfiles.Change.modified, normal_file) is True
+
+    def test_blocks_node_modules(self, tmp_repo: Path) -> None:
+        watch_filter = _make_watch_filter(tmp_repo, None)
+        pkg_file = str(tmp_repo / "node_modules" / "lodash" / "index.js")
+        assert watch_filter(watchfiles.Change.modified, pkg_file) is False
+
+    def test_handles_path_outside_repo(self, tmp_repo: Path, tmp_path: Path) -> None:
+        """Paths outside repo_path are passed through without filtering."""
+        watch_filter = _make_watch_filter(tmp_repo, None)
+        outside = str(tmp_path / "other" / "file.py")
+        # Outside repo_path: our filter defers to DefaultFilter (not hidden/ignored) → True.
+        assert watch_filter(watchfiles.Change.modified, outside) is True
 
 
 class TestGetHeadSha:


### PR DESCRIPTION
Linked Issue: https://github.com/harshkedia177/axon/issues/59

`watch_repo()` passed no filter to `watchfiles.awatch()`, so the watcher received raw FS events for every file — including `build/`, `dist/`, `node_modules/`, `mysql_data/`, and anything else in `.gitignore`. Under a build this produced a continuous flood of events that starved the event loop.

## Changes

### `src/axon/core/ingestion/watcher.py`
- **`_make_watch_filter(repo_path, gitignore_patterns)`** — new function returning a `watchfiles`-compatible callable that chains `watchfiles.DefaultFilter` with `should_ignore()`. Events for ignored paths are dropped before they ever reach the async loop.
- **`watch_repo()`** — passes `watch_filter=_make_watch_filter(repo_path, gitignore)` to `watchfiles.awatch()`.
- **`_reindex_files()` deleted-file branch** — added missing `should_ignore()` guard before calling `storage.remove_nodes_by_file()` (defense-in-depth; the filter above means ignored paths won't reach here in normal operation).

```python
# before — watches everything, processes changes to build/ on every compile
async for changes in watchfiles.awatch(repo_path, ...):
    ...

# after — ignored paths never surface as events
async for changes in watchfiles.awatch(
    repo_path,
    watch_filter=_make_watch_filter(repo_path, gitignore),
    ...
):
    ...
```

### `tests/core/test_watcher.py`
- `TestWatchFilter` (6 tests): covers `_make_watch_filter` for source files (allowed), `__pycache__` / `node_modules` (blocked via default patterns), custom gitignore patterns (`build/`), and paths outside the repo root.
- `test_skips_deleted_files_in_ignored_dirs`: verifies the deleted-file path in `_reindex_files()` also respects ignore rules.