### PR TITLE
harsh/embeddings/refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,4 +90,5 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 markers = [
     "allow_update_notice: run CLI tests with the real update notifier enabled",
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]

--- a/src/axon/cli/main.py
+++ b/src/axon/cli/main.py
@@ -33,7 +33,7 @@ from axon.core.diff import diff_branches, format_diff
 from axon.core.embeddings.embedder import _DEFAULT_MODEL
 from axon.core.ingestion.pipeline import PipelineResult, run_pipeline
 from axon.core.storage.base import EMBEDDING_DIMENSIONS
-from axon.core.ingestion.watcher import watch_repo
+from axon.core.ingestion.watcher import ensure_current_embeddings, watch_repo
 from axon.core.storage.kuzu_backend import KuzuBackend
 from axon.mcp import tools as mcp_tools
 from axon.mcp.server import main as mcp_main
@@ -62,6 +62,18 @@ def _load_storage(repo_path: Path | None = None) -> "KuzuBackend":  # noqa: F821
     storage = KuzuBackend()
     storage.initialize(db_path, read_only=True)
     return storage
+
+
+def _has_index_metadata(axon_dir: Path) -> bool:
+    return (axon_dir / "meta.json").exists()
+
+
+def _has_index_database(db_path: Path) -> bool:
+    return db_path.is_dir() and any(db_path.iterdir())
+
+
+def _has_existing_index(axon_dir: Path, db_path: Path) -> bool:
+    return _has_index_metadata(axon_dir) and _has_index_database(db_path)
 
 
 def _update_cache_path() -> Path:
@@ -418,7 +430,7 @@ def _initialize_writable_storage(
     axon_dir = repo_path / ".axon"
     db_path = axon_dir / "kuzu"
 
-    if not auto_index and not (axon_dir / "meta.json").exists():
+    if not auto_index and not _has_existing_index(axon_dir, db_path):
         console.print(
             "[red]Error:[/red] No index found. Run [cyan]axon analyze .[/cyan] first to index this codebase."
         )
@@ -429,7 +441,7 @@ def _initialize_writable_storage(
     storage = KuzuBackend()
     storage.initialize(db_path)
 
-    if not (axon_dir / "meta.json").exists():
+    if not _has_index_metadata(axon_dir):
         console.print("[bold]Running initial index...[/bold]")
         _, result = run_pipeline(repo_path, storage)
         meta = _build_meta(result, repo_path)
@@ -439,6 +451,8 @@ def _initialize_writable_storage(
             _register_in_global_registry(meta, repo_path)
         except Exception:
             logger.debug("Failed to register repo in global registry", exc_info=True)
+    else:
+        ensure_current_embeddings(storage, repo_path)
 
     return storage, axon_dir, db_path
 
@@ -568,10 +582,46 @@ def _run_shared_host(
         _clear_host_meta(repo_path)
         storage.close()
 
+def _run_background_embeddings(
+    graph: "KnowledgeGraph",
+    db_path: Path,
+    meta_path: Path,
+    repo_path: Path,
+) -> None:
+    """Generate embeddings in a background thread with its own storage connection."""
+    from axon.core.ingestion.pipeline import _run_embedding_phase, PipelineResult
+
+    bg_storage = KuzuBackend()
+    bg_storage.initialize(db_path)
+    try:
+        bg_result = PipelineResult()
+        _run_embedding_phase(graph, bg_storage, bg_result, lambda _phase, _pct: None)
+
+        # Update meta.json with embedding count.
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            meta["stats"]["embeddings"] = bg_result.embeddings
+            meta_path.write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+        except Exception:
+            logger.debug("Failed to update meta.json with embedding count", exc_info=True)
+
+        if bg_result.embeddings > 0:
+            console.print(
+                f"[dim]Background embeddings complete: {bg_result.embeddings} vectors generated.[/dim]"
+            )
+    except Exception:
+        logger.warning("Background embedding failed — semantic search unavailable", exc_info=True)
+    finally:
+        bg_storage.close()
+
+
 @app.command()
 def analyze(
     path: Path = typer.Argument(Path("."), help="Path to the repository to index."),
     no_embeddings: bool = typer.Option(False, "--no-embeddings", help="Skip vector embedding generation."),
+    foreground_embeddings: bool = typer.Option(
+        False, "--foreground-embeddings", help="Generate embeddings synchronously instead of in the background.",
+    ),
 ) -> None:
     """Index a repository into a knowledge graph."""
     repo_path = path.resolve()
@@ -588,6 +638,9 @@ def analyze(
     storage = KuzuBackend()
     storage.initialize(db_path)
 
+    # Run pipeline: skip embeddings here if we'll do them in the background.
+    run_embeddings_inline = foreground_embeddings and not no_embeddings
+
     result: PipelineResult | None = None
     with Progress(
         SpinnerColumn(),
@@ -600,11 +653,11 @@ def analyze(
         def on_progress(phase: str, pct: float) -> None:
             progress.update(task, description=f"{phase} ({pct:.0%})")
 
-        _, result = run_pipeline(
+        graph, result = run_pipeline(
             repo_path=repo_path,
             storage=storage,
             progress_callback=on_progress,
-            embeddings=not no_embeddings,
+            embeddings=run_embeddings_inline,
         )
 
     meta = _build_meta(result, repo_path)
@@ -615,6 +668,17 @@ def analyze(
         _register_in_global_registry(meta, repo_path)
     except Exception:
         logger.debug("Failed to register repo in global registry", exc_info=True)
+
+    storage.close()
+
+    # Launch background embedding thread if needed.
+    if not no_embeddings and not run_embeddings_inline:
+        embed_thread = threading.Thread(
+            target=_run_background_embeddings,
+            args=(graph, db_path, meta_path, repo_path),
+            daemon=True,
+        )
+        embed_thread.start()
 
     console.print()
     console.print("[bold green]Indexing complete.[/bold green]")
@@ -629,11 +693,15 @@ def analyze(
         console.print(f"  Dead code:      {result.dead_code}")
     if result.coupled_pairs > 0:
         console.print(f"  Coupled pairs:  {result.coupled_pairs}")
-    if result.embeddings > 0:
+    if run_embeddings_inline and result.embeddings > 0:
         console.print(f"  Embeddings:     {result.embeddings}")
+    elif not no_embeddings and not run_embeddings_inline:
+        console.print("  Embeddings:     [dim]generating in background...[/dim]")
     console.print(f"  Duration:       {result.duration_seconds:.2f}s")
 
-    storage.close()
+    # Wait for background embeddings to finish before exiting.
+    if not no_embeddings and not run_embeddings_inline:
+        embed_thread.join()
 
 @app.command()
 def status() -> None:
@@ -791,6 +859,8 @@ def watch() -> None:
             _register_in_global_registry(meta, repo_path)
         except Exception:
             logger.debug("Failed to register repo in global registry", exc_info=True)
+    else:
+        ensure_current_embeddings(storage, repo_path)
 
     console.print(f"[bold]Watching[/bold] {repo_path} for changes (Ctrl+C to stop)")
 
@@ -924,15 +994,20 @@ def ui(
         )
         return
 
-    db_path = repo_path / ".axon" / "kuzu"
-    if not db_path.exists():
-        console.print(
-            "[red]Error:[/red] No index found. Run [cyan]axon analyze .[/cyan] first to index this codebase."
-        )
-        raise typer.Exit(code=1)
+    storage, _, db_path = _initialize_writable_storage(repo_path, auto_index=False)
+    runtime = AxonRuntime(
+        storage=storage,
+        repo_path=repo_path,
+        watch=watch_files,
+        owns_storage=True,
+    )
 
     web_app = web_app_module.create_app(
-        db_path=db_path, repo_path=repo_path, watch=watch_files, dev=dev,
+        db_path=db_path,
+        repo_path=repo_path,
+        watch=watch_files,
+        dev=dev,
+        runtime=runtime,
     )
 
     if not no_open:

--- a/src/axon/cli/main.py
+++ b/src/axon/cli/main.py
@@ -402,11 +402,25 @@ def main(
     _maybe_notify_update(ctx.invoked_subcommand)
 
 
-def _initialize_writable_storage(repo_path: Path) -> tuple["KuzuBackend", Path, Path]:  # noqa: F821
-    """Open the repo database in read-write mode and ensure the initial index exists."""
+def _initialize_writable_storage(
+    repo_path: Path, *, auto_index: bool = True,
+) -> tuple["KuzuBackend", Path, Path]:  # noqa: F821
+    """Open the repo database in read-write mode.
+
+    If *auto_index* is False and no index exists, raises typer.Exit instead of
+    running the pipeline — callers like ``ui`` should tell the user to run
+    ``axon analyze .`` themselves.
+    """
     axon_dir = repo_path / ".axon"
-    axon_dir.mkdir(parents=True, exist_ok=True)
     db_path = axon_dir / "kuzu"
+
+    if not auto_index and not (axon_dir / "meta.json").exists():
+        console.print(
+            "[red]Error:[/red] No index found. Run [cyan]axon analyze .[/cyan] first to index this codebase."
+        )
+        raise typer.Exit(code=1)
+
+    axon_dir.mkdir(parents=True, exist_ok=True)
 
     storage = KuzuBackend()
     storage.initialize(db_path)
@@ -452,6 +466,7 @@ def _run_shared_host(
     announce_mcp: bool,
     expose_ui: bool,
     already_running_message: str,
+    auto_index: bool = True,
 ) -> None:
     """Run the shared Axon host with configurable UX messaging."""
     repo_path = Path.cwd().resolve()
@@ -462,7 +477,7 @@ def _run_shared_host(
             webbrowser.open(live_host["host_url"])
         return
 
-    storage, _, db_path = _initialize_writable_storage(repo_path)
+    storage, _, db_path = _initialize_writable_storage(repo_path, auto_index=auto_index)
     host_url, mcp_url = _build_host_urls(bind, port)
     lock = asyncio.Lock()
     runtime = AxonRuntime(
@@ -624,7 +639,7 @@ def status() -> None:
 
     if not meta_path.exists():
         console.print(
-            f"[red]Error:[/red] No index found at {repo_path}. Run 'axon analyze' first."
+            "[red]Error:[/red] No index found. Run [cyan]axon analyze .[/cyan] first to index this codebase."
         )
         raise typer.Exit(code=1)
 
@@ -732,31 +747,24 @@ def setup(
     cursor: bool = typer.Option(False, "--cursor", help="Configure MCP for Cursor."),
 ) -> None:
     """Configure MCP for Claude Code / Cursor."""
-    host_url, mcp_url = _build_host_urls(DEFAULT_HOST, DEFAULT_PORT)
-    hosted_claude_config = {
-        "type": "http",
-        "url": mcp_url,
-    }
-    hosted_cursor_config = {
-        "url": mcp_url,
-    }
-    legacy_stdio_config = {
+    stdio_config = {
         "command": "axon",
         "args": ["serve", "--watch"],
     }
 
     if claude or (not claude and not cursor):
         console.print("[bold]Claude Code[/bold]")
-        console.print(f"Recommended shared-host config (start with `axon host --watch` at {host_url}):")
-        console.print(json.dumps({"mcpServers": {"axon": hosted_claude_config}}, indent=2))
-        console.print("\n[dim]Legacy single-session stdio config:[/dim]")
-        console.print(json.dumps({"mcpServers": {"axon": legacy_stdio_config}}, indent=2))
+        console.print("Add to your [cyan].mcp.json[/cyan] or [cyan]~/.claude.json[/cyan]:\n")
+        console.print(json.dumps({"mcpServers": {"axon": stdio_config}}, indent=2))
+        console.print("\nOr run directly:")
+        console.print("[cyan]claude mcp add axon -- axon serve --watch[/cyan]")
 
     if cursor or (not claude and not cursor):
-        console.print("[bold]Add to your Cursor MCP config:[/bold]")
-        console.print(json.dumps({"axon": hosted_cursor_config}, indent=2))
-        console.print("\n[dim]Legacy single-session stdio config:[/dim]")
-        console.print(json.dumps({"axon": legacy_stdio_config}, indent=2))
+        console.print("[bold]Cursor[/bold]")
+        console.print("Add to your MCP config:\n")
+        console.print(json.dumps({"axon": stdio_config}, indent=2))
+
+    console.print("\n[dim]Then index your codebase with:[/dim] [cyan]axon analyze .[/cyan]")
 
 @app.command()
 def watch() -> None:
@@ -908,13 +916,14 @@ def ui(
             announce_mcp=False,
             expose_ui=True,
             already_running_message="[bold green]Axon UI[/bold green] available at {url}",
+            auto_index=False,
         )
         return
 
     db_path = repo_path / ".axon" / "kuzu"
     if not db_path.exists():
         console.print(
-            f"[red]Error:[/red] No index found at {repo_path}. Run 'axon analyze' first."
+            "[red]Error:[/red] No index found. Run [cyan]axon analyze .[/cyan] first to index this codebase."
         )
         raise typer.Exit(code=1)
 

--- a/src/axon/cli/main.py
+++ b/src/axon/cli/main.py
@@ -30,7 +30,9 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from axon import __version__
 from axon.core.diff import diff_branches, format_diff
+from axon.core.embeddings.embedder import _DEFAULT_MODEL
 from axon.core.ingestion.pipeline import PipelineResult, run_pipeline
+from axon.core.storage.base import EMBEDDING_DIMENSIONS
 from axon.core.ingestion.watcher import watch_repo
 from axon.core.storage.kuzu_backend import KuzuBackend
 from axon.mcp import tools as mcp_tools
@@ -178,6 +180,8 @@ def _build_meta(result: "PipelineResult", repo_path: Path) -> dict:  # noqa: F82
         "version": __version__,
         "name": repo_path.name,
         "path": str(repo_path),
+        "embedding_model": _DEFAULT_MODEL,
+        "embedding_dimensions": EMBEDDING_DIMENSIONS,
         "stats": {
             "files": result.files,
             "symbols": result.symbols,

--- a/src/axon/core/embeddings/embedder.py
+++ b/src/axon/core/embeddings/embedder.py
@@ -183,7 +183,7 @@ def embed_nodes(
     for node in nodes:
         text = generate_text(node, graph, class_method_idx)
         if text and text.strip():
-            texts.append(text)
+            texts.append(text[:_MAX_TEXT_CHARS])
             valid_nodes.append(node)
 
     if not texts:

--- a/src/axon/core/embeddings/embedder.py
+++ b/src/axon/core/embeddings/embedder.py
@@ -12,6 +12,7 @@ richness that makes embedding worthwhile.
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from typing import TYPE_CHECKING
 
@@ -38,7 +39,11 @@ def _get_model(model_name: str) -> "TextEmbedding":
         if cached is not None:
             return cached
         from fastembed import TextEmbedding
-        model = TextEmbedding(model_name=model_name)
+
+        # Cap ONNX threads to avoid saturating all CPU cores.
+        # Default to half the available cores (minimum 2).
+        max_threads = max(2, os.cpu_count() // 2) if os.cpu_count() else 2
+        model = TextEmbedding(model_name=model_name, threads=max_threads)
         _model_cache[model_name] = model
         return model
 
@@ -66,7 +71,7 @@ EMBEDDABLE_LABELS: frozenset[NodeLabel] = frozenset(
 
 _DEFAULT_MODEL = "nomic-ai/nomic-embed-text-v1.5"
 _DEFAULT_DIMENSIONS = EMBEDDING_DIMENSIONS  # 384 via Matryoshka
-_DEFAULT_BATCH_SIZE = 128
+_DEFAULT_BATCH_SIZE = 32
 _MAX_TEXT_CHARS = 8192
 
 

--- a/src/axon/core/embeddings/embedder.py
+++ b/src/axon/core/embeddings/embedder.py
@@ -11,17 +11,19 @@ richness that makes embedding worthwhile.
 
 from __future__ import annotations
 
+import logging
 import threading
 from typing import TYPE_CHECKING
 
 from axon.core.embeddings.text import build_class_method_index, generate_text
 from axon.core.graph.graph import KnowledgeGraph
 from axon.core.graph.model import NodeLabel
-from axon.core.storage.base import NodeEmbedding
+from axon.core.storage.base import EMBEDDING_DIMENSIONS, NodeEmbedding
 
 if TYPE_CHECKING:
     from fastembed import TextEmbedding
 
+logger = logging.getLogger(__name__)
 
 _model_cache: dict[str, "TextEmbedding"] = {}
 _model_lock = threading.Lock()
@@ -62,24 +64,60 @@ EMBEDDABLE_LABELS: frozenset[NodeLabel] = frozenset(
     }
 )
 
-_DEFAULT_MODEL = "BAAI/bge-small-en-v1.5"
+_DEFAULT_MODEL = "nomic-ai/nomic-embed-text-v1.5"
+_DEFAULT_DIMENSIONS = EMBEDDING_DIMENSIONS  # 384 via Matryoshka
+_DEFAULT_BATCH_SIZE = 128
+_MAX_TEXT_CHARS = 8192
 
 
-def embed_query(query: str, model_name: str = _DEFAULT_MODEL) -> list[float] | None:
+def embed_query(
+    query: str,
+    model_name: str = _DEFAULT_MODEL,
+    dimensions: int = _DEFAULT_DIMENSIONS,
+) -> list[float] | None:
     """Embed a single query string, returning ``None`` on failure."""
     if not query or not query.strip():
         return None
     try:
         model = _get_model(model_name)
-        return list(next(iter(model.embed([query]))))
+        vec = next(iter(model.query_embed(query)))
+        return vec[:dimensions].tolist()
     except Exception:
+        logger.warning("embed_query failed", exc_info=True)
         return None
+
+
+def _embed_node_list(
+    nodes: list,
+    texts: list[str],
+    model_name: str,
+    batch_size: int,
+    dimensions: int,
+) -> list[NodeEmbedding]:
+    """Embed a list of nodes with their corresponding texts."""
+    if not texts:
+        return []
+
+    model = _get_model(model_name)
+    vectors = list(model.passage_embed(texts, batch_size=batch_size))
+
+    results: list[NodeEmbedding] = []
+    for node, vector in zip(nodes, vectors):
+        results.append(
+            NodeEmbedding(
+                node_id=node.id,
+                embedding=vector[:dimensions].tolist(),
+            )
+        )
+
+    return results
 
 
 def embed_graph(
     graph: KnowledgeGraph,
-    model_name: str = "BAAI/bge-small-en-v1.5",
-    batch_size: int = 64,
+    model_name: str = _DEFAULT_MODEL,
+    batch_size: int = _DEFAULT_BATCH_SIZE,
+    dimensions: int = _DEFAULT_DIMENSIONS,
 ) -> list[NodeEmbedding]:
     """Generate embeddings for all embeddable nodes in the graph.
 
@@ -90,8 +128,10 @@ def embed_graph(
     Args:
         graph: The knowledge graph whose nodes should be embedded.
         model_name: The fastembed model identifier.  Defaults to
-            ``"BAAI/bge-small-en-v1.5"``.
-        batch_size: Number of texts to encode per batch.  Defaults to 64.
+            ``"nomic-ai/nomic-embed-text-v1.5"``.
+        batch_size: Number of texts to encode per batch.  Defaults to 128.
+        dimensions: Number of dimensions for Matryoshka truncation.
+            Defaults to 384.
 
     Returns:
         A list of :class:`NodeEmbedding` instances, one per embeddable node,
@@ -110,32 +150,21 @@ def embed_graph(
     for node in all_nodes:
         text = generate_text(node, graph, class_method_idx)
         if text and text.strip():
-            texts.append(text)
+            texts.append(text[:_MAX_TEXT_CHARS])
             nodes.append(node)
 
     if not texts:
         return []
 
-    model = _get_model(model_name)
-    vectors = list(model.embed(texts, batch_size=batch_size))
-
-    results: list[NodeEmbedding] = []
-    for node, vector in zip(nodes, vectors):
-        results.append(
-            NodeEmbedding(
-                node_id=node.id,
-                embedding=vector.tolist(),
-            )
-        )
-
-    return results
+    return _embed_node_list(nodes, texts, model_name, batch_size, dimensions)
 
 
 def embed_nodes(
     graph: KnowledgeGraph,
     node_ids: set[str],
-    model_name: str = "BAAI/bge-small-en-v1.5",
-    batch_size: int = 64,
+    model_name: str = _DEFAULT_MODEL,
+    batch_size: int = _DEFAULT_BATCH_SIZE,
+    dimensions: int = _DEFAULT_DIMENSIONS,
 ) -> list[NodeEmbedding]:
     """Like :func:`embed_graph`, but only for the given *node_ids*."""
     if not node_ids:
@@ -160,14 +189,4 @@ def embed_nodes(
     if not texts:
         return []
 
-    model = _get_model(model_name)
-    embeddings: list[NodeEmbedding] = []
-    for node, vector in zip(valid_nodes, model.embed(texts, batch_size=batch_size)):
-        embeddings.append(
-            NodeEmbedding(
-                node_id=node.id,
-                embedding=vector.tolist(),
-            )
-        )
-
-    return embeddings
+    return _embed_node_list(valid_nodes, texts, model_name, batch_size, dimensions)

--- a/src/axon/core/embeddings/text.py
+++ b/src/axon/core/embeddings/text.py
@@ -11,6 +11,11 @@ from __future__ import annotations
 from axon.core.graph.graph import KnowledgeGraph
 from axon.core.graph.model import GraphNode, NodeLabel, RelType
 
+# nomic-embed-text-v1.5 supports 8192 tokens, but embedding quality degrades
+# with very long inputs.  2048 tokens (~8192 chars at ~4 chars/token) is the
+# sweet spot.
+_MAX_TEXT_TOKENS = 2048
+
 
 def build_class_method_index(graph: KnowledgeGraph) -> dict[tuple[str, str], list[str]]:
     """Pre-build a mapping from (class_name, file_path) to sorted method names.
@@ -51,22 +56,27 @@ def generate_text(
     label = node.label
 
     if label in (NodeLabel.FUNCTION, NodeLabel.METHOD):
-        return _text_for_callable(node, graph)
-    if label == NodeLabel.CLASS:
-        return _text_for_class(node, graph, class_method_index)
-    if label == NodeLabel.FILE:
-        return _text_for_file(node, graph)
-    if label == NodeLabel.FOLDER:
-        return _text_for_folder(node, graph)
-    if label in (NodeLabel.INTERFACE, NodeLabel.TYPE_ALIAS, NodeLabel.ENUM):
-        return _text_for_type_definition(node, graph)
-    if label == NodeLabel.COMMUNITY:
-        return _text_for_community(node, graph)
-    if label == NodeLabel.PROCESS:
-        return _text_for_process(node, graph)
+        text = _text_for_callable(node, graph)
+    elif label == NodeLabel.CLASS:
+        text = _text_for_class(node, graph, class_method_index)
+    elif label == NodeLabel.FILE:
+        text = _text_for_file(node, graph)
+    elif label == NodeLabel.FOLDER:
+        text = _text_for_folder(node, graph)
+    elif label in (NodeLabel.INTERFACE, NodeLabel.TYPE_ALIAS, NodeLabel.ENUM):
+        text = _text_for_type_definition(node, graph)
+    elif label == NodeLabel.COMMUNITY:
+        text = _text_for_community(node, graph)
+    elif label == NodeLabel.PROCESS:
+        text = _text_for_process(node, graph)
+    else:
+        text = _header(node)
 
-    # Fallback for any unexpected label — still produce something useful.
-    return _header(node)
+    # Enforce token budget — truncate if exceeding ~2048 tokens
+    max_chars = _MAX_TEXT_TOKENS * 4
+    if len(text) > max_chars:
+        text = text[:max_chars]
+    return text
 
 def _text_for_callable(node: GraphNode, graph: KnowledgeGraph) -> str:
     """Build text for FUNCTION and METHOD nodes."""

--- a/src/axon/core/ingestion/pipeline.py
+++ b/src/axon/core/ingestion/pipeline.py
@@ -87,6 +87,26 @@ def _write_collected_edges(
         )
 
 
+def _run_embedding_phase(
+    graph: KnowledgeGraph,
+    storage: StorageBackend,
+    result: PipelineResult,
+    report: Callable[[str, float], None],
+) -> None:
+    """Generate and store embeddings synchronously."""
+    try:
+        node_embeddings = embed_graph(graph)
+        storage.store_embeddings(node_embeddings)
+        result.embeddings = len(node_embeddings)
+        report("Generating embeddings", 1.0)
+    except Exception:
+        logging.getLogger(__name__).warning(
+            "Embedding phase failed — search will use FTS only",
+            exc_info=True,
+        )
+        report("Generating embeddings", 1.0)
+
+
 def run_pipeline(
     repo_path: Path,
     storage: StorageBackend | None = None,
@@ -221,18 +241,8 @@ def run_pipeline(
         report("Loading to storage", 1.0)
 
         if embeddings:
-            try:
-                report("Generating embeddings", 0.0)
-                node_embeddings = embed_graph(graph)
-                storage.store_embeddings(node_embeddings)
-                result.embeddings = len(node_embeddings)
-                report("Generating embeddings", 1.0)
-            except Exception:
-                logging.getLogger(__name__).warning(
-                    "Embedding phase failed — search will use FTS only",
-                    exc_info=True,
-                )
-                report("Generating embeddings", 1.0)
+            report("Generating embeddings", 0.0)
+            _run_embedding_phase(graph, storage, result, report)
 
     result.duration_seconds = time.monotonic() - start
 

--- a/src/axon/core/ingestion/watcher.py
+++ b/src/axon/core/ingestion/watcher.py
@@ -195,7 +195,7 @@ def _run_incremental_global_phases(
         try:
             meta = json.loads(meta_path.read_text())
             stored_model = meta.get("embedding_model")
-            if stored_model is not None and stored_model != _DEFAULT_MODEL:
+            if stored_model != _DEFAULT_MODEL:
                 needs_full_reembed = True
         except Exception:
             pass

--- a/src/axon/core/ingestion/watcher.py
+++ b/src/axon/core/ingestion/watcher.py
@@ -48,6 +48,55 @@ MAX_DIRTY_AGE = 60.0
 _POLL_INTERVAL_MS = 500
 
 
+def _embedding_meta_path(repo_path: Path) -> Path:
+    return repo_path / ".axon" / "meta.json"
+
+
+def _load_embedding_meta(repo_path: Path) -> dict | None:
+    meta_path = _embedding_meta_path(repo_path)
+    if not meta_path.exists():
+        return None
+    try:
+        return json.loads(meta_path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.debug("Failed to read meta.json", exc_info=True)
+        return None
+
+
+def ensure_current_embeddings(storage: StorageBackend, repo_path: Path) -> bool:
+    """Re-embed the full graph when the stored embedding model is outdated."""
+    meta = _load_embedding_meta(repo_path)
+    if meta is None:
+        return False
+
+    stored_model = meta.get("embedding_model")
+    if stored_model == _DEFAULT_MODEL:
+        return False
+
+    logger.info(
+        "Embedding model changed from %s to %s, re-embedding all symbols",
+        stored_model or "unknown",
+        _DEFAULT_MODEL,
+    )
+
+    try:
+        graph = storage.load_graph()
+        embeddings = embed_graph(graph)
+        if embeddings:
+            storage.store_embeddings(embeddings)
+
+        meta["embedding_model"] = _DEFAULT_MODEL
+        meta["embedding_dimensions"] = EMBEDDING_DIMENSIONS
+        _embedding_meta_path(repo_path).write_text(
+            json.dumps(meta, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return True
+    except Exception:
+        logger.warning("Full re-embedding failed", exc_info=True)
+        return False
+
+
 def _get_head_sha(repo_path: Path) -> str | None:
     """Return the current git HEAD sha, or None if not in a git repo."""
     try:
@@ -188,36 +237,7 @@ def _run_incremental_global_phases(
             storage.add_relationships(coupled_rels)
         logger.info("Coupling: %d pairs", num_coupled)
 
-    # Check if embedding model changed — if so, re-embed everything
-    meta_path = repo_path / ".axon" / "meta.json"
-    needs_full_reembed = False
-    if meta_path.exists():
-        try:
-            meta = json.loads(meta_path.read_text())
-            stored_model = meta.get("embedding_model")
-            if stored_model != _DEFAULT_MODEL:
-                needs_full_reembed = True
-        except Exception:
-            pass
-
-    if needs_full_reembed:
-        logger.info("Embedding model changed, re-embedding all symbols")
-        try:
-            embeddings = embed_graph(graph)
-            if embeddings:
-                storage.store_embeddings(embeddings)
-            # Update meta with new model info
-            if meta_path.exists():
-                try:
-                    meta = json.loads(meta_path.read_text())
-                    meta["embedding_model"] = _DEFAULT_MODEL
-                    meta["embedding_dimensions"] = EMBEDDING_DIMENSIONS
-                    meta_path.write_text(json.dumps(meta, indent=2) + "\n")
-                except Exception:
-                    logger.debug("Failed to update meta.json", exc_info=True)
-        except Exception:
-            logger.warning("Full re-embedding failed", exc_info=True)
-    else:
+    if not ensure_current_embeddings(storage, repo_path):
         dirty_node_ids = _compute_dirty_node_ids(graph, dirty_files)
         if dirty_node_ids:
             logger.info("Re-embedding %d nodes...", len(dirty_node_ids))

--- a/src/axon/core/ingestion/watcher.py
+++ b/src/axon/core/ingestion/watcher.py
@@ -13,6 +13,7 @@ native debouncing.  Changes are processed in tiers:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import subprocess
 import time
@@ -22,7 +23,8 @@ import watchfiles
 
 from axon.config.ignore import load_gitignore, should_ignore
 from axon.config.languages import is_supported
-from axon.core.embeddings.embedder import embed_nodes
+from axon.core.embeddings.embedder import _DEFAULT_MODEL, embed_graph, embed_nodes
+from axon.core.storage.base import EMBEDDING_DIMENSIONS
 from axon.core.graph.graph import KnowledgeGraph
 from axon.core.graph.model import NodeLabel, RelType
 from axon.core.ingestion.community import process_communities
@@ -186,15 +188,45 @@ def _run_incremental_global_phases(
             storage.add_relationships(coupled_rels)
         logger.info("Coupling: %d pairs", num_coupled)
 
-    dirty_node_ids = _compute_dirty_node_ids(graph, dirty_files)
-    if dirty_node_ids:
-        logger.info("Re-embedding %d nodes...", len(dirty_node_ids))
+    # Check if embedding model changed — if so, re-embed everything
+    meta_path = repo_path / ".axon" / "meta.json"
+    needs_full_reembed = False
+    if meta_path.exists():
         try:
-            embeddings = embed_nodes(graph, dirty_node_ids)
-            if embeddings:
-                storage.upsert_embeddings(embeddings)
+            meta = json.loads(meta_path.read_text())
+            stored_model = meta.get("embedding_model")
+            if stored_model is not None and stored_model != _DEFAULT_MODEL:
+                needs_full_reembed = True
         except Exception:
-            logger.warning("Incremental embedding failed", exc_info=True)
+            pass
+
+    if needs_full_reembed:
+        logger.info("Embedding model changed, re-embedding all symbols")
+        try:
+            embeddings = embed_graph(graph)
+            if embeddings:
+                storage.store_embeddings(embeddings)
+            # Update meta with new model info
+            if meta_path.exists():
+                try:
+                    meta = json.loads(meta_path.read_text())
+                    meta["embedding_model"] = _DEFAULT_MODEL
+                    meta["embedding_dimensions"] = EMBEDDING_DIMENSIONS
+                    meta_path.write_text(json.dumps(meta, indent=2) + "\n")
+                except Exception:
+                    logger.debug("Failed to update meta.json", exc_info=True)
+        except Exception:
+            logger.warning("Full re-embedding failed", exc_info=True)
+    else:
+        dirty_node_ids = _compute_dirty_node_ids(graph, dirty_files)
+        if dirty_node_ids:
+            logger.info("Re-embedding %d nodes...", len(dirty_node_ids))
+            try:
+                embeddings = embed_nodes(graph, dirty_node_ids)
+                if embeddings:
+                    storage.upsert_embeddings(embeddings)
+            except Exception:
+                logger.warning("Incremental embedding failed", exc_info=True)
 
     storage.rebuild_fts_indexes()
 

--- a/src/axon/core/storage/base.py
+++ b/src/axon/core/storage/base.py
@@ -26,12 +26,23 @@ class SearchResult:
     label: str = ""
     snippet: str = ""
 
+EMBEDDING_DIMENSIONS: int = 384
+"""Number of dimensions expected for all embedding vectors."""
+
+
 @dataclass
 class NodeEmbedding:
     """An embedding vector associated with a graph node."""
 
     node_id: str
     embedding: list[float] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.embedding and len(self.embedding) != EMBEDDING_DIMENSIONS:
+            raise ValueError(
+                f"Expected embedding of {EMBEDDING_DIMENSIONS} dimensions, "
+                f"got {len(self.embedding)}"
+            )
 
 @runtime_checkable
 class StorageBackend(Protocol):

--- a/src/axon/core/storage/kuzu_backend.py
+++ b/src/axon/core/storage/kuzu_backend.py
@@ -12,7 +12,6 @@ import csv
 import hashlib
 import json
 import logging
-import math
 import tempfile
 import threading
 import time
@@ -92,21 +91,12 @@ def escape_cypher(value: str) -> str:
     return value
 
 
-def _safe_vec_literal(vector: list[float]) -> str:
-    parts = []
-    for v in vector:
-        f = float(v)
-        if not math.isfinite(f):
-            raise ValueError(f"Non-finite float in embedding vector: {f}")
-        parts.append(repr(f))
-    return "[" + ", ".join(parts) + "]"
-
 def _table_for_id(node_id: str) -> str | None:
     """Extract the table name from a node ID by mapping its label prefix."""
     prefix = node_id.split(":", 1)[0]
     return _LABEL_TO_TABLE.get(prefix)
 
-_EMBEDDING_PROPERTIES = "node_id STRING, vec DOUBLE[], PRIMARY KEY(node_id)"
+_EMBEDDING_PROPERTIES = "node_id STRING, vec FLOAT[384], PRIMARY KEY(node_id)"
 
 class KuzuBackend:
     """StorageBackend implementation backed by KuzuDB.
@@ -628,15 +618,15 @@ class KuzuBackend:
         """
         conn = self._require_conn()
         limit = int(limit)
-        vec_literal = _safe_vec_literal(vector)
 
         try:
             with self._lock:
                 result = conn.execute(
-                    f"MATCH (e:Embedding) "
-                    f"RETURN e.node_id, "
-                    f"array_cosine_similarity(e.vec, {vec_literal}) AS sim "
-                    f"ORDER BY sim DESC LIMIT {limit}"
+                    "MATCH (e:Embedding) "
+                    "RETURN e.node_id, "
+                    "array_cosine_similarity(e.vec, CAST($vec, 'FLOAT[384]')) AS sim "
+                    "ORDER BY sim DESC LIMIT $lim",
+                    parameters={"vec": vector, "lim": limit},
                 )
         except Exception:
             logger.debug("vector_search failed", exc_info=True)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -288,7 +288,7 @@ class TestSetup:
         assert "Claude Code" in result.output
         assert "Cursor" in result.output
         assert '"axon"' in result.output
-        assert '"type": "http"' in result.output
+        assert '"serve"' in result.output
 
     def test_setup_claude_only(self) -> None:
         result = runner.invoke(app, ["setup", "--claude"])

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -4,11 +4,12 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from click.exceptions import Exit
 import pytest
 from typer.testing import CliRunner
 
 from axon import __version__
-from axon.cli.main import _register_in_global_registry, app
+from axon.cli.main import _initialize_writable_storage, _register_in_global_registry, app
 
 runner = CliRunner()
 
@@ -375,16 +376,50 @@ class TestUi:
 
     def test_ui_direct_skips_host_attach(self, tmp_path: Path, monkeypatch: "pytest.MonkeyPatch") -> None:
         monkeypatch.chdir(tmp_path)
-        axon_dir = tmp_path / ".axon" / "kuzu"
-        axon_dir.mkdir(parents=True)
+        mock_storage = MagicMock()
         with patch("axon.cli.main._get_live_host_info") as mock_host_info:
-            with patch("axon.web.app.create_app") as mock_create_app:
-                with patch("uvicorn.run") as mock_run:
-                    result = runner.invoke(app, ["ui", "--direct", "--no-open"])
+            with patch(
+                "axon.cli.main._initialize_writable_storage",
+                return_value=(mock_storage, tmp_path / ".axon", tmp_path / ".axon" / "kuzu"),
+            ):
+                with patch("axon.web.app.create_app") as mock_create_app:
+                    with patch("uvicorn.run") as mock_run:
+                        result = runner.invoke(app, ["ui", "--direct", "--no-open"])
         assert result.exit_code == 0
         mock_host_info.assert_not_called()
         mock_create_app.assert_called_once()
         mock_run.assert_called_once()
+
+
+class TestWritableStorageInitialization:
+    def test_requires_database_when_auto_index_disabled(self, tmp_path: Path) -> None:
+        axon_dir = tmp_path / ".axon"
+        axon_dir.mkdir()
+        (axon_dir / "meta.json").write_text("{}", encoding="utf-8")
+
+        with pytest.raises(Exit):
+            _initialize_writable_storage(tmp_path, auto_index=False)
+
+    def test_runs_embedding_migration_for_existing_index(self, tmp_path: Path) -> None:
+        axon_dir = tmp_path / ".axon"
+        db_path = axon_dir / "kuzu"
+        db_path.mkdir(parents=True)
+        (db_path / "data.kz").write_text("", encoding="utf-8")
+        (axon_dir / "meta.json").write_text("{}", encoding="utf-8")
+
+        mock_storage = MagicMock()
+        with patch("axon.cli.main.KuzuBackend", return_value=mock_storage):
+            with patch("axon.cli.main.ensure_current_embeddings") as mock_migrate:
+                storage, returned_axon_dir, returned_db_path = _initialize_writable_storage(
+                    tmp_path,
+                    auto_index=False,
+                )
+
+        assert storage is mock_storage
+        assert returned_axon_dir == axon_dir
+        assert returned_db_path == db_path
+        mock_storage.initialize.assert_called_once_with(db_path)
+        mock_migrate.assert_called_once_with(mock_storage, tmp_path)
 
 
 class TestWatch:

--- a/tests/core/test_embedder.py
+++ b/tests/core/test_embedder.py
@@ -127,7 +127,7 @@ class TestModelDefaults:
         assert _DEFAULT_DIMENSIONS == 384
 
     def test_default_batch_size(self) -> None:
-        assert _DEFAULT_BATCH_SIZE == 128
+        assert _DEFAULT_BATCH_SIZE == 32
 
 
 class TestEmbeddableLabels:
@@ -318,7 +318,9 @@ class TestEmbedGraphModelConfig:
 
         embed_graph(sample_graph)
 
-        mock_te_cls.assert_called_once_with(model_name="nomic-ai/nomic-embed-text-v1.5")
+        mock_te_cls.assert_called_once()
+        assert mock_te_cls.call_args.kwargs["model_name"] == "nomic-ai/nomic-embed-text-v1.5"
+        assert mock_te_cls.call_args.kwargs["threads"] >= 2
 
     @patch("fastembed.TextEmbedding")
     def test_custom_model_name(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
@@ -330,7 +332,8 @@ class TestEmbedGraphModelConfig:
 
         embed_graph(sample_graph, model_name="BAAI/bge-base-en-v1.5")
 
-        mock_te_cls.assert_called_once_with(model_name="BAAI/bge-base-en-v1.5")
+        mock_te_cls.assert_called_once()
+        assert mock_te_cls.call_args.kwargs["model_name"] == "BAAI/bge-base-en-v1.5"
 
     @patch("fastembed.TextEmbedding")
     def test_custom_batch_size_passed_to_passage_embed(
@@ -424,7 +427,7 @@ class TestEmbedGraphBatchProcessing:
         assert all(len(r.embedding) == EMBEDDING_DIMENSIONS for r in results)
 
     @patch("fastembed.TextEmbedding")
-    def test_default_batch_size_is_128(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
+    def test_default_batch_size_is_32(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
         mock_model = MagicMock()
         mock_model.passage_embed.return_value = iter(
             [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
@@ -434,8 +437,8 @@ class TestEmbedGraphBatchProcessing:
         embed_graph(sample_graph)
 
         embed_call = mock_model.passage_embed.call_args
-        assert embed_call.kwargs.get("batch_size") == 128 or (
-            len(embed_call.args) > 1 and embed_call.args[1] == 128
+        assert embed_call.kwargs.get("batch_size") == 32 or (
+            len(embed_call.args) > 1 and embed_call.args[1] == 32
         )
 
 

--- a/tests/core/test_embedder.py
+++ b/tests/core/test_embedder.py
@@ -5,15 +5,24 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from axon.core.embeddings.embedder import EMBEDDABLE_LABELS, _get_model, embed_graph, embed_nodes
+from axon.core.embeddings.embedder import (
+    EMBEDDABLE_LABELS,
+    _DEFAULT_BATCH_SIZE,
+    _DEFAULT_DIMENSIONS,
+    _DEFAULT_MODEL,
+    _get_model,
+    embed_graph,
+    embed_nodes,
+    embed_query,
+)
 from axon.core.graph.graph import KnowledgeGraph
 from axon.core.graph.model import GraphNode, GraphRelationship, NodeLabel, RelType, generate_id
 from axon.core.storage.base import EMBEDDING_DIMENSIONS, NodeEmbedding
 
 
-def _vec384(base: list[float] | None = None) -> np.ndarray:
-    """Return a 384-d numpy array, zero-padded from *base* (or all zeros)."""
-    v = np.zeros(EMBEDDING_DIMENSIONS)
+def _vec768(base: list[float] | None = None) -> np.ndarray:
+    """Return a 768-d numpy array (nomic native dim), zero-padded from *base*."""
+    v = np.zeros(768)
     if base:
         v[: len(base)] = base
     return v
@@ -110,6 +119,17 @@ def all_label_graph() -> KnowledgeGraph:
     return graph
 
 
+class TestModelDefaults:
+    def test_default_model_is_nomic(self) -> None:
+        assert "nomic" in _DEFAULT_MODEL
+
+    def test_default_dimensions(self) -> None:
+        assert _DEFAULT_DIMENSIONS == 384
+
+    def test_default_batch_size(self) -> None:
+        assert _DEFAULT_BATCH_SIZE == 128
+
+
 class TestEmbeddableLabels:
     def test_contains_expected_labels(self) -> None:
         expected = {
@@ -136,8 +156,8 @@ class TestEmbedGraphBasic:
     @patch("fastembed.TextEmbedding")
     def test_returns_node_embeddings(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -151,8 +171,8 @@ class TestEmbedGraphBasic:
         self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph
     ) -> None:
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -163,21 +183,21 @@ class TestEmbedGraphBasic:
             assert all(isinstance(v, float) for v in r.embedding)
 
     @patch("fastembed.TextEmbedding")
-    def test_embedding_values_match(
+    def test_embedding_values_match_after_truncation(
         self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph
     ) -> None:
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
         results = embed_graph(sample_graph)
 
-        # We should get two results with the two mock vectors
+        # After Matryoshka truncation to 384 dims, values should match first 384 of 768
         embeddings = [r.embedding for r in results]
-        vec_a = _vec384([0.1, 0.2, 0.3]).tolist()
-        vec_b = _vec384([0.4, 0.5, 0.6]).tolist()
+        vec_a = _vec768([0.1, 0.2, 0.3])[:384].tolist()
+        vec_b = _vec768([0.4, 0.5, 0.6])[:384].tolist()
         assert vec_a in embeddings or pytest.approx(vec_a) in embeddings
         assert vec_b in embeddings or pytest.approx(vec_b) in embeddings
 
@@ -186,8 +206,8 @@ class TestEmbedGraphBasic:
         self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph
     ) -> None:
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -204,8 +224,8 @@ class TestEmbedGraphFiltering:
         self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph
     ) -> None:
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -220,8 +240,8 @@ class TestEmbedGraphFiltering:
     ) -> None:
         embeddable_count = 7  # FILE, FUNCTION, CLASS, METHOD, INTERFACE, TYPE_ALIAS, ENUM
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([0.1, 0.2, 0.3]) for _ in range(embeddable_count)]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([0.1, 0.2, 0.3]) for _ in range(embeddable_count)]
         )
         mock_te_cls.return_value = mock_model
 
@@ -239,8 +259,8 @@ class TestEmbedGraphFiltering:
     ) -> None:
         embeddable_count = 7
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([0.1, 0.2, 0.3]) for _ in range(embeddable_count)]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([0.1, 0.2, 0.3]) for _ in range(embeddable_count)]
         )
         mock_te_cls.return_value = mock_model
 
@@ -260,7 +280,7 @@ class TestEmbedGraphEmpty:
     @patch("fastembed.TextEmbedding")
     def test_empty_graph_returns_empty_list(self, mock_te_cls: MagicMock) -> None:
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter([])
+        mock_model.passage_embed.return_value = iter([])
         mock_te_cls.return_value = mock_model
 
         graph = KnowledgeGraph()
@@ -271,7 +291,7 @@ class TestEmbedGraphEmpty:
     @patch("fastembed.TextEmbedding")
     def test_graph_with_only_non_embeddable_returns_empty(self, mock_te_cls: MagicMock) -> None:
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter([])
+        mock_model.passage_embed.return_value = iter([])
         mock_te_cls.return_value = mock_model
 
         graph = KnowledgeGraph()
@@ -291,20 +311,20 @@ class TestEmbedGraphModelConfig:
     @patch("fastembed.TextEmbedding")
     def test_default_model_name(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
         embed_graph(sample_graph)
 
-        mock_te_cls.assert_called_once_with(model_name="BAAI/bge-small-en-v1.5")
+        mock_te_cls.assert_called_once_with(model_name="nomic-ai/nomic-embed-text-v1.5")
 
     @patch("fastembed.TextEmbedding")
     def test_custom_model_name(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -313,19 +333,19 @@ class TestEmbedGraphModelConfig:
         mock_te_cls.assert_called_once_with(model_name="BAAI/bge-base-en-v1.5")
 
     @patch("fastembed.TextEmbedding")
-    def test_custom_batch_size_passed_to_embed(
+    def test_custom_batch_size_passed_to_passage_embed(
         self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph
     ) -> None:
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
         embed_graph(sample_graph, batch_size=32)
 
-        # Verify batch_size was passed to embed()
-        embed_call = mock_model.embed.call_args
+        # Verify batch_size was passed to passage_embed()
+        embed_call = mock_model.passage_embed.call_args
         assert embed_call.kwargs.get("batch_size") == 32 or (
             len(embed_call.args) > 1 and embed_call.args[1] == 32
         )
@@ -342,8 +362,8 @@ class TestEmbedGraphTextGeneration:
     ) -> None:
         mock_gen_text.return_value = "mock text"
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -362,15 +382,15 @@ class TestEmbedGraphTextGeneration:
     ) -> None:
         mock_gen_text.side_effect = ["text for foo", "text for Bar"]
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
         embed_graph(sample_graph)
 
-        # The texts list passed to model.embed should contain both texts
-        embed_call_args = mock_model.embed.call_args
+        # The texts list passed to model.passage_embed should contain both texts
+        embed_call_args = mock_model.passage_embed.call_args
         texts_arg = embed_call_args.args[0] if embed_call_args.args else embed_call_args.kwargs.get("documents", [])
         assert "text for foo" in texts_arg
         assert "text for Bar" in texts_arg
@@ -392,31 +412,71 @@ class TestEmbedGraphBatchProcessing:
             )
 
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([float(i), float(i + 1), float(i + 2)]) for i in range(count)]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([float(i), float(i + 1), float(i + 2)]) for i in range(count)]
         )
         mock_te_cls.return_value = mock_model
 
         results = embed_graph(graph, batch_size=16)
 
         assert len(results) == count
-        # Each embedding should have 384 dimensions
+        # Each embedding should have 384 dimensions (Matryoshka truncation)
         assert all(len(r.embedding) == EMBEDDING_DIMENSIONS for r in results)
 
     @patch("fastembed.TextEmbedding")
-    def test_default_batch_size_is_64(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
+    def test_default_batch_size_is_128(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
         embed_graph(sample_graph)
 
-        embed_call = mock_model.embed.call_args
-        assert embed_call.kwargs.get("batch_size") == 64 or (
-            len(embed_call.args) > 1 and embed_call.args[1] == 64
+        embed_call = mock_model.passage_embed.call_args
+        assert embed_call.kwargs.get("batch_size") == 128 or (
+            len(embed_call.args) > 1 and embed_call.args[1] == 128
         )
+
+
+class TestEmbedGraphNomic:
+    @patch("fastembed.TextEmbedding")
+    def test_uses_passage_embed(self, mock_te_cls, sample_graph):
+        mock_model = MagicMock()
+        mock_model.passage_embed.return_value = iter([_vec768([0.1]), _vec768([0.2])])
+        mock_te_cls.return_value = mock_model
+        results = embed_graph(sample_graph)
+        mock_model.passage_embed.assert_called_once()
+        mock_model.embed.assert_not_called()
+
+    @patch("fastembed.TextEmbedding")
+    def test_matryoshka_truncation(self, mock_te_cls, sample_graph):
+        mock_model = MagicMock()
+        mock_model.passage_embed.return_value = iter([_vec768([0.1]), _vec768([0.2])])
+        mock_te_cls.return_value = mock_model
+        results = embed_graph(sample_graph)
+        for r in results:
+            assert len(r.embedding) == 384
+
+
+class TestEmbedQueryNomic:
+    @patch("fastembed.TextEmbedding")
+    def test_uses_query_embed(self, mock_te_cls):
+        mock_model = MagicMock()
+        mock_model.query_embed.return_value = iter([np.array([0.5] * 768)])
+        mock_te_cls.return_value = mock_model
+        result = embed_query("test query")
+        mock_model.query_embed.assert_called_once()
+        mock_model.embed.assert_not_called()
+
+    @patch("fastembed.TextEmbedding")
+    def test_query_embed_truncates_to_384(self, mock_te_cls):
+        mock_model = MagicMock()
+        mock_model.query_embed.return_value = iter([np.array([0.5] * 768)])
+        mock_te_cls.return_value = mock_model
+        result = embed_query("test query")
+        assert result is not None
+        assert len(result) == 384
 
 
 def _make_incremental_graph() -> KnowledgeGraph:
@@ -468,14 +528,14 @@ class TestEmbeddingAlignment:
             "text for func_a" if node.id == node_a.id else "text for func_b"
         )
 
-        # Two distinguishable embedding vectors.
-        embedding_a = _vec384([1.0, 0.0, 0.0])
-        embedding_b = _vec384([0.0, 1.0, 0.0])
+        # Two distinguishable embedding vectors (768d, truncated to 384).
+        embedding_a = _vec768([1.0, 0.0, 0.0])
+        embedding_b = _vec768([0.0, 1.0, 0.0])
 
         mock_model = MagicMock()
         mock_te_cls.return_value = mock_model
         # The model yields vectors in the same order texts are passed.
-        mock_model.embed.return_value = iter([embedding_a, embedding_b])
+        mock_model.passage_embed.return_value = iter([embedding_a, embedding_b])
 
         results = embed_graph(graph)
 
@@ -494,7 +554,7 @@ class TestEmbedNodes:
         node_ids = {generate_id(NodeLabel.FUNCTION, "src/a.py", "func_a")}
 
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter([_vec384([0.1, 0.2, 0.3])])
+        mock_model.passage_embed.return_value = iter([_vec768([0.1, 0.2, 0.3])])
         mock_te_cls.return_value = mock_model
 
         results = embed_nodes(graph, node_ids)
@@ -532,8 +592,8 @@ class TestEmbedNodes:
         node_ids = {id_a, id_b}
 
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter(
-            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
+        mock_model.passage_embed.return_value = iter(
+            [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -549,7 +609,7 @@ class TestEmbedNodes:
         id_a = generate_id(NodeLabel.FUNCTION, "src/a.py", "func_a")
 
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter([_vec384([1.0, 2.0, 3.0])])
+        mock_model.passage_embed.return_value = iter([_vec768([1.0, 2.0, 3.0])])
         mock_te_cls.return_value = mock_model
 
         results = embed_nodes(graph, {id_a})
@@ -557,4 +617,6 @@ class TestEmbedNodes:
         assert len(results) == 1
         assert results[0].node_id == id_a
         assert isinstance(results[0].embedding, list)
-        assert results[0].embedding == pytest.approx(_vec384([1.0, 2.0, 3.0]).tolist())
+        # After Matryoshka truncation, we get first 384 dims of the 768d vector
+        expected = _vec768([1.0, 2.0, 3.0])[:384].tolist()
+        assert results[0].embedding == pytest.approx(expected)

--- a/tests/core/test_embedder.py
+++ b/tests/core/test_embedder.py
@@ -8,7 +8,15 @@ import pytest
 from axon.core.embeddings.embedder import EMBEDDABLE_LABELS, _get_model, embed_graph, embed_nodes
 from axon.core.graph.graph import KnowledgeGraph
 from axon.core.graph.model import GraphNode, GraphRelationship, NodeLabel, RelType, generate_id
-from axon.core.storage.base import NodeEmbedding
+from axon.core.storage.base import EMBEDDING_DIMENSIONS, NodeEmbedding
+
+
+def _vec384(base: list[float] | None = None) -> np.ndarray:
+    """Return a 384-d numpy array, zero-padded from *base* (or all zeros)."""
+    v = np.zeros(EMBEDDING_DIMENSIONS)
+    if base:
+        v[: len(base)] = base
+    return v
 
 
 @pytest.fixture(autouse=True)
@@ -129,7 +137,7 @@ class TestEmbedGraphBasic:
     def test_returns_node_embeddings(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([0.1, 0.2, 0.3]), np.array([0.4, 0.5, 0.6])]
+            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -144,7 +152,7 @@ class TestEmbedGraphBasic:
     ) -> None:
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([0.1, 0.2, 0.3]), np.array([0.4, 0.5, 0.6])]
+            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -160,7 +168,7 @@ class TestEmbedGraphBasic:
     ) -> None:
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([0.1, 0.2, 0.3]), np.array([0.4, 0.5, 0.6])]
+            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -168,8 +176,10 @@ class TestEmbedGraphBasic:
 
         # We should get two results with the two mock vectors
         embeddings = [r.embedding for r in results]
-        assert [0.1, 0.2, 0.3] in embeddings or pytest.approx([0.1, 0.2, 0.3]) in embeddings
-        assert [0.4, 0.5, 0.6] in embeddings or pytest.approx([0.4, 0.5, 0.6]) in embeddings
+        vec_a = _vec384([0.1, 0.2, 0.3]).tolist()
+        vec_b = _vec384([0.4, 0.5, 0.6]).tolist()
+        assert vec_a in embeddings or pytest.approx(vec_a) in embeddings
+        assert vec_b in embeddings or pytest.approx(vec_b) in embeddings
 
     @patch("fastembed.TextEmbedding")
     def test_node_ids_are_correct(
@@ -177,7 +187,7 @@ class TestEmbedGraphBasic:
     ) -> None:
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([0.1, 0.2, 0.3]), np.array([0.4, 0.5, 0.6])]
+            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -195,7 +205,7 @@ class TestEmbedGraphFiltering:
     ) -> None:
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([0.1, 0.2, 0.3]), np.array([0.4, 0.5, 0.6])]
+            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -211,7 +221,7 @@ class TestEmbedGraphFiltering:
         embeddable_count = 7  # FILE, FUNCTION, CLASS, METHOD, INTERFACE, TYPE_ALIAS, ENUM
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([0.1, 0.2, 0.3]) for _ in range(embeddable_count)]
+            [_vec384([0.1, 0.2, 0.3]) for _ in range(embeddable_count)]
         )
         mock_te_cls.return_value = mock_model
 
@@ -230,7 +240,7 @@ class TestEmbedGraphFiltering:
         embeddable_count = 7
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([0.1, 0.2, 0.3]) for _ in range(embeddable_count)]
+            [_vec384([0.1, 0.2, 0.3]) for _ in range(embeddable_count)]
         )
         mock_te_cls.return_value = mock_model
 
@@ -282,7 +292,7 @@ class TestEmbedGraphModelConfig:
     def test_default_model_name(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([0.1, 0.2, 0.3]), np.array([0.4, 0.5, 0.6])]
+            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -294,7 +304,7 @@ class TestEmbedGraphModelConfig:
     def test_custom_model_name(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([0.1, 0.2, 0.3]), np.array([0.4, 0.5, 0.6])]
+            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -308,7 +318,7 @@ class TestEmbedGraphModelConfig:
     ) -> None:
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([0.1, 0.2, 0.3]), np.array([0.4, 0.5, 0.6])]
+            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -333,7 +343,7 @@ class TestEmbedGraphTextGeneration:
         mock_gen_text.return_value = "mock text"
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([0.1, 0.2, 0.3]), np.array([0.4, 0.5, 0.6])]
+            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -353,7 +363,7 @@ class TestEmbedGraphTextGeneration:
         mock_gen_text.side_effect = ["text for foo", "text for Bar"]
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([0.1, 0.2, 0.3]), np.array([0.4, 0.5, 0.6])]
+            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -383,21 +393,21 @@ class TestEmbedGraphBatchProcessing:
 
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([float(i), float(i + 1), float(i + 2)]) for i in range(count)]
+            [_vec384([float(i), float(i + 1), float(i + 2)]) for i in range(count)]
         )
         mock_te_cls.return_value = mock_model
 
         results = embed_graph(graph, batch_size=16)
 
         assert len(results) == count
-        # Each embedding should have 3 dimensions
-        assert all(len(r.embedding) == 3 for r in results)
+        # Each embedding should have 384 dimensions
+        assert all(len(r.embedding) == EMBEDDING_DIMENSIONS for r in results)
 
     @patch("fastembed.TextEmbedding")
     def test_default_batch_size_is_64(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([0.1, 0.2, 0.3]), np.array([0.4, 0.5, 0.6])]
+            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -459,8 +469,8 @@ class TestEmbeddingAlignment:
         )
 
         # Two distinguishable embedding vectors.
-        embedding_a = np.array([1.0, 0.0, 0.0])
-        embedding_b = np.array([0.0, 1.0, 0.0])
+        embedding_a = _vec384([1.0, 0.0, 0.0])
+        embedding_b = _vec384([0.0, 1.0, 0.0])
 
         mock_model = MagicMock()
         mock_te_cls.return_value = mock_model
@@ -484,7 +494,7 @@ class TestEmbedNodes:
         node_ids = {generate_id(NodeLabel.FUNCTION, "src/a.py", "func_a")}
 
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter([np.array([0.1, 0.2, 0.3])])
+        mock_model.embed.return_value = iter([_vec384([0.1, 0.2, 0.3])])
         mock_te_cls.return_value = mock_model
 
         results = embed_nodes(graph, node_ids)
@@ -523,7 +533,7 @@ class TestEmbedNodes:
 
         mock_model = MagicMock()
         mock_model.embed.return_value = iter(
-            [np.array([0.1, 0.2, 0.3]), np.array([0.4, 0.5, 0.6])]
+            [_vec384([0.1, 0.2, 0.3]), _vec384([0.4, 0.5, 0.6])]
         )
         mock_te_cls.return_value = mock_model
 
@@ -539,7 +549,7 @@ class TestEmbedNodes:
         id_a = generate_id(NodeLabel.FUNCTION, "src/a.py", "func_a")
 
         mock_model = MagicMock()
-        mock_model.embed.return_value = iter([np.array([1.0, 2.0, 3.0])])
+        mock_model.embed.return_value = iter([_vec384([1.0, 2.0, 3.0])])
         mock_te_cls.return_value = mock_model
 
         results = embed_nodes(graph, {id_a})
@@ -547,4 +557,4 @@ class TestEmbedNodes:
         assert len(results) == 1
         assert results[0].node_id == id_a
         assert isinstance(results[0].embedding, list)
-        assert results[0].embedding == pytest.approx([1.0, 2.0, 3.0])
+        assert results[0].embedding == pytest.approx(_vec384([1.0, 2.0, 3.0]).tolist())

--- a/tests/core/test_embedder_integration.py
+++ b/tests/core/test_embedder_integration.py
@@ -1,0 +1,52 @@
+"""Integration test that loads the real nomic model.
+
+Marked slow — only runs with ``pytest -m slow``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from axon.core.embeddings.embedder import embed_query, embed_graph, _DEFAULT_DIMENSIONS
+from axon.core.graph.graph import KnowledgeGraph
+from axon.core.graph.model import GraphNode, NodeLabel
+
+
+@pytest.mark.slow
+class TestEmbeddingIntegration:
+    def test_embed_query_returns_correct_dimensions(self) -> None:
+        result = embed_query("a function that sorts a list")
+        assert result is not None
+        assert len(result) == _DEFAULT_DIMENSIONS
+
+    def test_semantic_similarity_ranking(self) -> None:
+        """Verify that semantically similar queries produce similar vectors."""
+        import numpy as np
+
+        vec_sort = embed_query("sorting algorithm")
+        vec_db = embed_query("database connection pool")
+        vec_sort2 = embed_query("function that sorts items in a list")
+
+        assert vec_sort is not None
+        assert vec_db is not None
+        assert vec_sort2 is not None
+
+        # sort and sort2 should be more similar than sort and db
+        sim_related = np.dot(vec_sort, vec_sort2)
+        sim_unrelated = np.dot(vec_sort, vec_db)
+        assert sim_related > sim_unrelated, (
+            f"Expected related similarity ({sim_related:.4f}) > "
+            f"unrelated similarity ({sim_unrelated:.4f})"
+        )
+
+    def test_embed_graph_roundtrip(self) -> None:
+        graph = KnowledgeGraph()
+        graph.add_node(GraphNode(
+            id="function:src/sort.py:quicksort",
+            label=NodeLabel.FUNCTION,
+            name="quicksort",
+            file_path="src/sort.py",
+            signature="def quicksort(arr: list) -> list:",
+        ))
+        results = embed_graph(graph)
+        assert len(results) == 1
+        assert len(results[0].embedding) == _DEFAULT_DIMENSIONS

--- a/tests/core/test_embedding_migration.py
+++ b/tests/core/test_embedding_migration.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import json
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from axon.core.embeddings.embedder import _DEFAULT_MODEL
+from axon.core.ingestion.watcher import ensure_current_embeddings
 
 
 def test_needs_reembed_model_mismatch() -> None:
@@ -18,3 +22,44 @@ def test_needs_reembed_missing_key() -> None:
 def test_no_reembed_when_matching() -> None:
     meta = {"embedding_model": _DEFAULT_MODEL}
     assert meta.get("embedding_model") == _DEFAULT_MODEL
+
+
+def test_ensure_current_embeddings_reembeds_and_updates_meta(tmp_path) -> None:
+    repo_path = tmp_path
+    axon_dir = repo_path / ".axon"
+    axon_dir.mkdir()
+    meta_path = axon_dir / "meta.json"
+    meta_path.write_text(
+        json.dumps({"embedding_model": "BAAI/bge-small-en-v1.5"}) + "\n",
+        encoding="utf-8",
+    )
+
+    storage = MagicMock()
+    storage.load_graph.return_value = object()
+
+    with patch("axon.core.ingestion.watcher.embed_graph", return_value={"node-1": [0.1, 0.2]}):
+        migrated = ensure_current_embeddings(storage, repo_path)
+
+    assert migrated is True
+    storage.load_graph.assert_called_once_with()
+    storage.store_embeddings.assert_called_once_with({"node-1": [0.1, 0.2]})
+    updated_meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert updated_meta["embedding_model"] == _DEFAULT_MODEL
+
+
+def test_ensure_current_embeddings_noop_when_model_matches(tmp_path) -> None:
+    repo_path = tmp_path
+    axon_dir = repo_path / ".axon"
+    axon_dir.mkdir()
+    (axon_dir / "meta.json").write_text(
+        json.dumps({"embedding_model": _DEFAULT_MODEL}) + "\n",
+        encoding="utf-8",
+    )
+
+    storage = MagicMock()
+
+    migrated = ensure_current_embeddings(storage, repo_path)
+
+    assert migrated is False
+    storage.load_graph.assert_not_called()
+    storage.store_embeddings.assert_not_called()

--- a/tests/core/test_embedding_migration.py
+++ b/tests/core/test_embedding_migration.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from axon.core.embeddings.embedder import _DEFAULT_MODEL
+
+
+def test_needs_reembed_model_mismatch() -> None:
+    meta = {"embedding_model": "BAAI/bge-small-en-v1.5"}
+    assert meta.get("embedding_model") != _DEFAULT_MODEL
+
+
+def test_needs_reembed_missing_key() -> None:
+    meta = {"version": "1.0.0", "stats": {}}
+    assert meta.get("embedding_model") is None
+
+
+def test_no_reembed_when_matching() -> None:
+    meta = {"embedding_model": _DEFAULT_MODEL}
+    assert meta.get("embedding_model") == _DEFAULT_MODEL

--- a/tests/core/test_embedding_text.py
+++ b/tests/core/test_embedding_text.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from axon.core.embeddings.text import generate_text
+from axon.core.embeddings.text import generate_text, build_class_method_index, _MAX_TEXT_TOKENS
 from axon.core.graph.graph import KnowledgeGraph
 from axon.core.graph.model import (
     GraphNode,
@@ -369,3 +369,55 @@ class TestEdgeCases:
         assert "Worker" in text
         assert "transform" in text
         assert "Data" in text
+
+
+def _make_hub_function(num_callees: int = 100) -> tuple[KnowledgeGraph, GraphNode]:
+    """Create a function node that calls many other functions."""
+    graph = KnowledgeGraph()
+    hub = GraphNode(
+        id="function:src/hub.py:hub_func",
+        label=NodeLabel.FUNCTION,
+        name="hub_func",
+        file_path="src/hub.py",
+        signature="def hub_func(a, b, c, d, e):",
+    )
+    graph.add_node(hub)
+    for i in range(num_callees):
+        callee = GraphNode(
+            id=f"function:src/mod{i}.py:callee_{i}",
+            label=NodeLabel.FUNCTION,
+            name=f"callee_with_a_long_name_{i}",
+            file_path=f"src/mod{i}.py",
+        )
+        graph.add_node(callee)
+        graph.add_relationship(GraphRelationship(
+            id=f"calls:{hub.id}->{callee.id}",
+            type=RelType.CALLS,
+            source=hub.id,
+            target=callee.id,
+        ))
+    return graph, hub
+
+
+class TestTextBudget:
+    def test_hub_function_stays_within_budget(self) -> None:
+        graph, hub = _make_hub_function(num_callees=200)
+        idx = build_class_method_index(graph)
+        text = generate_text(hub, graph, idx)
+        max_chars = _MAX_TEXT_TOKENS * 4
+        assert len(text) <= max_chars, f"Text is {len(text)} chars, budget is {max_chars}"
+
+    def test_small_function_is_not_truncated(self) -> None:
+        graph = KnowledgeGraph()
+        fn = GraphNode(
+            id="function:src/a.py:small",
+            label=NodeLabel.FUNCTION,
+            name="small",
+            file_path="src/a.py",
+            signature="def small():",
+        )
+        graph.add_node(fn)
+        idx = build_class_method_index(graph)
+        text = generate_text(fn, graph, idx)
+        assert "small" in text
+        assert "signature:" in text

--- a/tests/core/test_kuzu_backend.py
+++ b/tests/core/test_kuzu_backend.py
@@ -368,8 +368,8 @@ class TestDeleteSyntheticNodes:
 
 class TestUpsertEmbeddings:
     def test_upserts_without_wiping(self, backend: KuzuBackend) -> None:
-        emb_a = NodeEmbedding(node_id="function:src/a.py:alpha", embedding=[1.0, 2.0])
-        emb_b = NodeEmbedding(node_id="function:src/a.py:beta", embedding=[3.0, 4.0])
+        emb_a = NodeEmbedding(node_id="function:src/a.py:alpha", embedding=[1.0] * 384)
+        emb_b = NodeEmbedding(node_id="function:src/a.py:beta", embedding=[3.0] * 384)
 
         backend.store_embeddings([emb_a])
         backend.upsert_embeddings([emb_b])
@@ -382,11 +382,12 @@ class TestUpsertEmbeddings:
         assert "function:src/a.py:beta" in node_ids
 
     def test_updates_existing_embedding(self, backend: KuzuBackend) -> None:
-        emb = NodeEmbedding(node_id="function:src/a.py:alpha", embedding=[1.0, 2.0])
+        emb = NodeEmbedding(node_id="function:src/a.py:alpha", embedding=[1.0] * 384)
         backend.store_embeddings([emb])
 
+        updated_vec = [9.0] + [0.0] * 383
         updated = NodeEmbedding(
-            node_id="function:src/a.py:alpha", embedding=[9.0, 8.0]
+            node_id="function:src/a.py:alpha", embedding=updated_vec
         )
         backend.upsert_embeddings([updated])
 
@@ -396,7 +397,7 @@ class TestUpsertEmbeddings:
         )
         assert len(rows) == 1
         assert rows[0][0][0] == 9.0
-        assert rows[0][0][1] == 8.0
+        assert rows[0][0][1] == 0.0
 
 
 class TestUpdateDeadFlags:

--- a/tests/core/test_kuzu_search.py
+++ b/tests/core/test_kuzu_search.py
@@ -151,11 +151,12 @@ class TestEmbeddingsAndVectorSearch:
         backend.add_nodes([node])
 
         # Store an embedding for that node.
-        emb = NodeEmbedding(node_id=node.id, embedding=[1.0, 0.0, 0.0])
+        vec = [1.0] + [0.0] * 383
+        emb = NodeEmbedding(node_id=node.id, embedding=vec)
         backend.store_embeddings([emb])
 
         # Search with the same vector -- cosine similarity should be 1.0.
-        results = backend.vector_search([1.0, 0.0, 0.0], limit=5)
+        results = backend.vector_search(vec, limit=5)
         assert len(results) >= 1
         top = results[0]
         assert top.node_id == node.id
@@ -163,7 +164,7 @@ class TestEmbeddingsAndVectorSearch:
         assert top.node_name == "embed_func"
 
     def test_vector_search_empty(self, backend: KuzuBackend) -> None:
-        results = backend.vector_search([1.0, 0.0, 0.0], limit=5)
+        results = backend.vector_search([1.0] + [0.0] * 383, limit=5)
         assert results == []
 
     def test_vector_search_ranking(self, backend: KuzuBackend) -> None:
@@ -172,12 +173,15 @@ class TestEmbeddingsAndVectorSearch:
         backend.add_nodes([n1, n2])
 
         # close_func embedding is close to query, far_func is orthogonal.
+        close_vec = [0.9, 0.1] + [0.0] * 382
+        far_vec = [0.0, 0.0, 1.0] + [0.0] * 381
         backend.store_embeddings([
-            NodeEmbedding(node_id=n1.id, embedding=[0.9, 0.1, 0.0]),
-            NodeEmbedding(node_id=n2.id, embedding=[0.0, 0.0, 1.0]),
+            NodeEmbedding(node_id=n1.id, embedding=close_vec),
+            NodeEmbedding(node_id=n2.id, embedding=far_vec),
         ])
 
-        results = backend.vector_search([1.0, 0.0, 0.0], limit=5)
+        query_vec = [1.0] + [0.0] * 383
+        results = backend.vector_search(query_vec, limit=5)
         assert len(results) == 2
         assert results[0].node_id == n1.id
         assert results[0].score > results[1].score
@@ -188,28 +192,30 @@ class TestEmbeddingsAndVectorSearch:
         for i in range(5):
             n = _make_node(name=f"vfunc_{i}", file_path=f"src/v{i}.py")
             nodes.append(n)
-            # All somewhat similar embeddings.
-            vec = [0.0] * 5
+            # All somewhat similar embeddings — one-hot in first 5 dims, rest zeros.
+            vec = [0.0] * 384
             vec[i] = 1.0
             embeddings.append(NodeEmbedding(node_id=n.id, embedding=vec))
         backend.add_nodes(nodes)
         backend.store_embeddings(embeddings)
 
-        results = backend.vector_search([1.0, 0.5, 0.3, 0.1, 0.0], limit=2)
+        query_vec = [1.0, 0.5, 0.3, 0.1, 0.0] + [0.0] * 379
+        results = backend.vector_search(query_vec, limit=2)
         assert len(results) == 2
 
     def test_store_embeddings_upsert(self, backend: KuzuBackend) -> None:
         node = _make_node(name="upsert_func", file_path="src/u.py")
         backend.add_nodes([node])
 
-        emb1 = NodeEmbedding(node_id=node.id, embedding=[1.0, 0.0])
+        emb1 = NodeEmbedding(node_id=node.id, embedding=[1.0] + [0.0] * 383)
         backend.store_embeddings([emb1])
 
-        emb2 = NodeEmbedding(node_id=node.id, embedding=[0.0, 1.0])
+        emb2 = NodeEmbedding(node_id=node.id, embedding=[0.0, 1.0] + [0.0] * 382)
         backend.store_embeddings([emb2])
 
-        # Search with [0, 1] should find it with high similarity.
-        results = backend.vector_search([0.0, 1.0], limit=5)
+        # Search with [0, 1, 0...] should find it with high similarity.
+        query_vec = [0.0, 1.0] + [0.0] * 382
+        results = backend.vector_search(query_vec, limit=5)
         assert len(results) == 1
         assert results[0].score == pytest.approx(1.0, abs=1e-6)
 

--- a/tests/core/test_storage_base.py
+++ b/tests/core/test_storage_base.py
@@ -39,10 +39,10 @@ class TestNodeEmbedding:
         assert emb.embedding == []
 
     def test_creation_with_data(self) -> None:
-        vec = [0.1, 0.2, 0.3]
+        vec = [0.1] * 384
         emb = NodeEmbedding(node_id="n2", embedding=vec)
         assert emb.node_id == "n2"
-        assert emb.embedding == [0.1, 0.2, 0.3]
+        assert emb.embedding == [0.1] * 384
 
     def test_embedding_default_is_independent(self) -> None:
         a = NodeEmbedding(node_id="a")


### PR DESCRIPTION
- **refactor: enhance writable storage initialization and error messaging in Axon CLI**
- **feat(embeddings): switch to nomic-embed-text-v1.5 with passage_embed/query_embed**
- **feat(embeddings): add token budget to text generation**
- **feat(storage): switch to FLOAT[384] schema and parameterized vector queries**
- **feat(embeddings): add model metadata to meta.json and auto-migration on model change**
- **test(embeddings): add integration test with real nomic model**
- **fix(embeddings): apply _MAX_TEXT_CHARS in embed_nodes, treat missing model key as mismatch**
- **feat(embeddings): enhance embedding management and background processing**
