### PR TITLE
feat: optional CUDA/GPU acceleration for embeddings

### DIFF
--- a/src/axon/cli/main.py
+++ b/src/axon/cli/main.py
@@ -30,7 +30,11 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from axon import __version__
 from axon.core.diff import diff_branches, format_diff
-from axon.core.embeddings.embedder import _DEFAULT_MODEL
+from axon.core.embeddings.embedder import (
+    _DEFAULT_MODEL,
+    configure_cuda,
+    validate_cuda,
+)
 from axon.core.ingestion.pipeline import PipelineResult, run_pipeline
 from axon.core.storage.base import EMBEDDING_DIMENSIONS
 from axon.core.ingestion.watcher import ensure_current_embeddings, watch_repo
@@ -49,6 +53,7 @@ DEFAULT_MANAGED_PORT = 8421
 UPDATE_CHECK_INTERVAL_SECONDS = 60 * 60 * 24
 UPDATE_CHECK_URL = "https://pypi.org/pypi/axoniq/json"
 UPDATE_CHECK_SKIP_COMMANDS = {"mcp", "serve", "host"}
+
 
 def _load_storage(repo_path: Path | None = None) -> "KuzuBackend":  # noqa: F821
     target = (repo_path or Path.cwd()).resolve()
@@ -432,7 +437,8 @@ def _initialize_writable_storage(
 
     if not auto_index and not _has_existing_index(axon_dir, db_path):
         console.print(
-            "[red]Error:[/red] No index found. Run [cyan]axon analyze .[/cyan] first to index this codebase."
+            "[red]Error:[/red] No index found. "
+            "Run [cyan]axon analyze .[/cyan] first to index this codebase."
         )
         raise typer.Exit(code=1)
 
@@ -607,7 +613,8 @@ def _run_background_embeddings(
 
         if bg_result.embeddings > 0:
             console.print(
-                f"[dim]Background embeddings complete: {bg_result.embeddings} vectors generated.[/dim]"
+                f"[dim]Background embeddings complete: "
+                f"{bg_result.embeddings} vectors generated.[/dim]"
             )
     except Exception:
         logger.warning("Background embedding failed — semantic search unavailable", exc_info=True)
@@ -615,12 +622,30 @@ def _run_background_embeddings(
         bg_storage.close()
 
 
+def _configure_and_validate_cuda(cuda_flag: bool) -> None:
+    """Configure CUDA from --cuda flag and validate before pipeline runs."""
+    if cuda_flag:
+        configure_cuda(True)
+    try:
+        validate_cuda()
+    except RuntimeError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(code=1)
+
+
 @app.command()
 def analyze(
     path: Path = typer.Argument(Path("."), help="Path to the repository to index."),
-    no_embeddings: bool = typer.Option(False, "--no-embeddings", help="Skip vector embedding generation."),
+    no_embeddings: bool = typer.Option(
+        False, "--no-embeddings", help="Skip vector embedding generation."
+    ),
     foreground_embeddings: bool = typer.Option(
-        False, "--foreground-embeddings", help="Generate embeddings synchronously instead of in the background.",
+        False,
+        "--foreground-embeddings",
+        help="Generate embeddings synchronously instead of in the background.",
+    ),
+    cuda: bool = typer.Option(
+        False, "--cuda", help="Use CUDA GPU acceleration for embedding generation."
     ),
 ) -> None:
     """Index a repository into a knowledge graph."""
@@ -640,6 +665,7 @@ def analyze(
 
     # Run pipeline: skip embeddings here if we'll do them in the background.
     run_embeddings_inline = foreground_embeddings and not no_embeddings
+    _configure_and_validate_cuda(cuda)
 
     result: PipelineResult | None = None
     with Progress(
@@ -711,7 +737,8 @@ def status() -> None:
 
     if not meta_path.exists():
         console.print(
-            "[red]Error:[/red] No index found. Run [cyan]axon analyze .[/cyan] first to index this codebase."
+            "[red]Error:[/red] No index found. "
+            "Run [cyan]axon analyze .[/cyan] first to index this codebase."
         )
         raise typer.Exit(code=1)
 
@@ -839,8 +866,13 @@ def setup(
     console.print("\n[dim]Then index your codebase with:[/dim] [cyan]axon analyze .[/cyan]")
 
 @app.command()
-def watch() -> None:
+def watch(
+    cuda: bool = typer.Option(
+        False, "--cuda", help="Use CUDA GPU acceleration for embedding generation."
+    ),
+) -> None:
     """Watch mode — re-index on file changes."""
+    _configure_and_validate_cuda(cuda)
     repo_path = Path.cwd().resolve()
     axon_dir = repo_path / ".axon"
     axon_dir.mkdir(parents=True, exist_ok=True)
@@ -873,7 +905,9 @@ def watch() -> None:
 
 @app.command()
 def diff(
-    branch_range: str = typer.Argument(..., help="Branch range for comparison (e.g. main..feature)."),
+    branch_range: str = typer.Argument(
+        ..., help="Branch range for comparison (e.g. main..feature)."
+    ),
 ) -> None:
     """Structural branch comparison."""
     repo_path = Path.cwd().resolve()
@@ -893,14 +927,24 @@ def mcp() -> None:
 
 @app.command()
 def host(
-    port: int = typer.Option(DEFAULT_PORT, "--port", "-p", help="Port to serve UI and HTTP MCP on."),
-    bind: str = typer.Option(DEFAULT_HOST, "--bind", help="Host interface to bind the shared host to."),
+    port: int = typer.Option(
+        DEFAULT_PORT, "--port", "-p", help="Port to serve UI and HTTP MCP on."
+    ),
+    bind: str = typer.Option(
+        DEFAULT_HOST, "--bind", help="Host interface to bind the shared host to."
+    ),
     no_open: bool = typer.Option(False, "--no-open", help="Don't auto-open browser."),
-    watch: bool = typer.Option(True, "--watch/--no-watch", help="Enable file watching with auto-reindex."),
+    watch: bool = typer.Option(
+        True, "--watch/--no-watch", help="Enable file watching with auto-reindex."
+    ),
     dev: bool = typer.Option(False, "--dev", help="Proxy to Vite dev server for HMR."),
     managed: bool = typer.Option(False, "--managed", hidden=True),
+    cuda: bool = typer.Option(
+        False, "--cuda", help="Use CUDA GPU acceleration for embedding generation."
+    ),
 ) -> None:
     """Run the shared Axon host for UI and multi-session HTTP MCP clients."""
+    _configure_and_validate_cuda(cuda)
     _run_shared_host(
         port=port,
         bind=bind,
@@ -917,9 +961,15 @@ def host(
 
 @app.command()
 def serve(
-    watch: bool = typer.Option(False, "--watch", "-w", help="Enable file watching with auto-reindex."),
+    watch: bool = typer.Option(
+        False, "--watch", "-w", help="Enable file watching with auto-reindex."
+    ),
+    cuda: bool = typer.Option(
+        False, "--cuda", help="Use CUDA GPU acceleration for embedding generation."
+    ),
 ) -> None:
     """Start MCP server, optionally with live file watching."""
+    _configure_and_validate_cuda(cuda)
     if not watch:
         asyncio.run(mcp_main())
         return

--- a/src/axon/core/embeddings/embedder.py
+++ b/src/axon/core/embeddings/embedder.py
@@ -82,7 +82,12 @@ def _get_model(model_name: str) -> "TextEmbedding":
                         "/CUDA-ExecutionProvider.html"
                     )
         else:
-            model = TextEmbedding(model_name=model_name, threads=max_threads)
+            # Explicitly disable CUDA to override fastembed's Device.AUTO
+            # default, which would auto-detect and use GPU when
+            # onnxruntime-gpu is installed.
+            model = TextEmbedding(
+                model_name=model_name, threads=max_threads, cuda=False
+            )
         _model_cache[cache_key] = model
         return model
 

--- a/src/axon/core/embeddings/embedder.py
+++ b/src/axon/core/embeddings/embedder.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import warnings
 from typing import TYPE_CHECKING
 
 from axon.core.embeddings.text import build_class_method_index, generate_text
@@ -26,21 +27,32 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_model_cache: dict[str, "TextEmbedding"] = {}
+_model_cache: dict[tuple[str, bool], "TextEmbedding"] = {}
 _model_lock = threading.Lock()
+_cuda_enabled: bool = False
 
-# BGE-small max sequence is 512 tokens (~2000 chars).  Truncating long
-# descriptions avoids wasting tokenisation and padding time on text that
-# the model would discard anyway.
-_MAX_TEXT_CHARS = 2000
+
+def configure_cuda(enabled: bool) -> None:
+    """Enable or disable CUDA for all embedding operations."""
+    global _cuda_enabled
+    _cuda_enabled = enabled
+
+
+def _resolve_cuda() -> bool:
+    """Return True if CUDA is enabled via configure_cuda() or AXON_CUDA env var."""
+    return _cuda_enabled or os.environ.get(
+        "AXON_CUDA", ""
+    ).strip() in ("1", "true", "yes")
 
 
 def _get_model(model_name: str) -> "TextEmbedding":
-    cached = _model_cache.get(model_name)
+    cuda = _resolve_cuda()
+    cache_key = (model_name, cuda)
+    cached = _model_cache.get(cache_key)
     if cached is not None:
         return cached
     with _model_lock:
-        cached = _model_cache.get(model_name)
+        cached = _model_cache.get(cache_key)
         if cached is not None:
             return cached
         from fastembed import TextEmbedding
@@ -48,8 +60,30 @@ def _get_model(model_name: str) -> "TextEmbedding":
         # Cap ONNX threads to avoid saturating all CPU cores.
         # Default to half the available cores (minimum 2).
         max_threads = max(2, os.cpu_count() // 2) if os.cpu_count() else 2
-        model = TextEmbedding(model_name=model_name, threads=max_threads)
-        _model_cache[model_name] = model
+        if cuda:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                model = TextEmbedding(
+                    model_name=model_name, threads=max_threads, cuda=True
+                )
+            for w in caught:
+                if issubclass(w.category, RuntimeWarning) and (
+                    "CUDAExecutionProvider" in str(w.message)
+                ):
+                    raise RuntimeError(
+                        "--cuda / AXON_CUDA requested but "
+                        "CUDAExecutionProvider failed to initialize.\n"
+                        "Install CUDA dependencies:\n"
+                        "  pip install onnxruntime-gpu "
+                        "nvidia-cublas-cu12 nvidia-cudnn-cu12 "
+                        "nvidia-cufft-cu12 nvidia-curand-cu12 "
+                        "nvidia-cuda-runtime-cu12\n"
+                        "See https://onnxruntime.ai/docs/execution-providers"
+                        "/CUDA-ExecutionProvider.html"
+                    )
+        else:
+            model = TextEmbedding(model_name=model_name, threads=max_threads)
+        _model_cache[cache_key] = model
         return model
 
 
@@ -60,6 +94,18 @@ def _get_model_cache_clear() -> None:
 
 
 _get_model.cache_clear = _get_model_cache_clear  # type: ignore[attr-defined]
+
+
+def validate_cuda() -> None:
+    """Eagerly initialize the default model to validate CUDA configuration.
+
+    Raises RuntimeError if CUDA was requested but CUDAExecutionProvider
+    failed to initialize.
+    """
+    if not _resolve_cuda():
+        return
+    _get_model(_DEFAULT_MODEL)
+
 
 # Labels worth embedding — skip Folder, Community, Process (structural only).
 EMBEDDABLE_LABELS: frozenset[NodeLabel] = frozenset(

--- a/src/axon/core/embeddings/embedder.py
+++ b/src/axon/core/embeddings/embedder.py
@@ -127,7 +127,11 @@ EMBEDDABLE_LABELS: frozenset[NodeLabel] = frozenset(
 
 _DEFAULT_MODEL = "nomic-ai/nomic-embed-text-v1.5"
 _DEFAULT_DIMENSIONS = EMBEDDING_DIMENSIONS  # 384 via Matryoshka
-_DEFAULT_BATCH_SIZE = 32
+# Nomic-embed-text-v1.5 has 12 attention heads and 2048-token context.
+# With long texts, each batch element's attention matrix is ~192 MB
+# (12 * 2048 * 2048 * 4 bytes).  Batch size 8 keeps peak memory under
+# ~2 GB for the attention pass, safe for both CPU and 8 GB GPUs.
+_DEFAULT_BATCH_SIZE = 8
 _MAX_TEXT_CHARS = 8192
 
 

--- a/tests/core/test_embedder.py
+++ b/tests/core/test_embedder.py
@@ -33,9 +33,11 @@ def _vec768(base: list[float] | None = None) -> np.ndarray:
 
 
 @pytest.fixture(autouse=True)
-def _clear_model_cache():
-    """Clear the lru_cache on _get_model before each test so mocks work."""
+def _clear_model_cache(monkeypatch):
+    """Reset embedding state before each test so mocks work."""
     _get_model.cache_clear()
+    configure_cuda(False)
+    monkeypatch.delenv("AXON_CUDA", raising=False)
     yield
     _get_model.cache_clear()
 
@@ -694,14 +696,14 @@ class TestCudaSupport:
     def test_get_model_no_cuda_by_default(
         self, mock_te_cls: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """TextEmbedding is instantiated without cuda kwarg when CUDA is off."""
+        """TextEmbedding is instantiated with cuda=False to override auto-detect."""
         monkeypatch.delenv("AXON_CUDA", raising=False)
         mock_te_cls.return_value = MagicMock()
 
         _get_model("test-model")
 
         _, kwargs = mock_te_cls.call_args
-        assert not kwargs.get("cuda")
+        assert kwargs.get("cuda") is False
 
     @patch("fastembed.TextEmbedding")
     def test_cuda_cache_key_separation(

--- a/tests/core/test_embedder.py
+++ b/tests/core/test_embedder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -11,10 +12,13 @@ from axon.core.embeddings.embedder import (
     _DEFAULT_DIMENSIONS,
     _DEFAULT_MODEL,
     _get_model,
+    configure_cuda,
     embed_graph,
     embed_nodes,
     embed_query,
+    validate_cuda,
 )
+from axon.core.embeddings.embedder import _resolve_cuda
 from axon.core.graph.graph import KnowledgeGraph
 from axon.core.graph.model import GraphNode, GraphRelationship, NodeLabel, RelType, generate_id
 from axon.core.storage.base import EMBEDDING_DIMENSIONS, NodeEmbedding
@@ -154,7 +158,9 @@ class TestEmbeddableLabels:
 
 class TestEmbedGraphBasic:
     @patch("fastembed.TextEmbedding")
-    def test_returns_node_embeddings(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
+    def test_returns_node_embeddings(
+        self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph
+    ) -> None:
         mock_model = MagicMock()
         mock_model.passage_embed.return_value = iter(
             [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
@@ -394,7 +400,10 @@ class TestEmbedGraphTextGeneration:
 
         # The texts list passed to model.passage_embed should contain both texts
         embed_call_args = mock_model.passage_embed.call_args
-        texts_arg = embed_call_args.args[0] if embed_call_args.args else embed_call_args.kwargs.get("documents", [])
+        texts_arg = (
+            embed_call_args.args[0] if embed_call_args.args
+            else embed_call_args.kwargs.get("documents", [])
+        )
         assert "text for foo" in texts_arg
         assert "text for Bar" in texts_arg
 
@@ -427,7 +436,9 @@ class TestEmbedGraphBatchProcessing:
         assert all(len(r.embedding) == EMBEDDING_DIMENSIONS for r in results)
 
     @patch("fastembed.TextEmbedding")
-    def test_default_batch_size_is_32(self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph) -> None:
+    def test_default_batch_size_is_32(
+        self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph
+    ) -> None:
         mock_model = MagicMock()
         mock_model.passage_embed.return_value = iter(
             [_vec768([0.1, 0.2, 0.3]), _vec768([0.4, 0.5, 0.6])]
@@ -623,3 +634,137 @@ class TestEmbedNodes:
         # After Matryoshka truncation, we get first 384 dims of the 768d vector
         expected = _vec768([1.0, 2.0, 3.0])[:384].tolist()
         assert results[0].embedding == pytest.approx(expected)
+
+
+class TestCudaSupport:
+    """CUDA support flag and model initialization tests."""
+
+    def test_cuda_disabled_by_default(self) -> None:
+        """_resolve_cuda returns False with no flag set and no env var."""
+        assert _resolve_cuda() is False
+
+    def test_configure_cuda_sets_flag(self) -> None:
+        """configure_cuda(True) causes _resolve_cuda to return True."""
+        try:
+            configure_cuda(True)
+            assert _resolve_cuda() is True
+        finally:
+            configure_cuda(False)
+
+    def test_axon_cuda_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """AXON_CUDA=1 env var enables CUDA without calling configure_cuda."""
+        monkeypatch.setenv("AXON_CUDA", "1")
+        assert _resolve_cuda() is True
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("1", True),
+            ("true", True),
+            ("yes", True),
+            ("0", False),
+            ("false", False),
+            ("", False),
+        ],
+    )
+    def test_axon_cuda_env_var_values(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        value: str,
+        expected: bool,
+    ) -> None:
+        """AXON_CUDA env var is recognized only for truthy values."""
+        monkeypatch.setenv("AXON_CUDA", value)
+        assert _resolve_cuda() is expected
+
+    @patch("fastembed.TextEmbedding")
+    def test_get_model_passes_cuda_to_text_embedding(
+        self, mock_te_cls: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """TextEmbedding is instantiated with cuda=True when AXON_CUDA=1."""
+        monkeypatch.setenv("AXON_CUDA", "1")
+        mock_te_cls.return_value = MagicMock()
+
+        _get_model("test-model")
+
+        _, kwargs = mock_te_cls.call_args
+        assert kwargs.get("cuda") is True
+
+    @patch("fastembed.TextEmbedding")
+    def test_get_model_no_cuda_by_default(
+        self, mock_te_cls: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """TextEmbedding is instantiated without cuda kwarg when CUDA is off."""
+        monkeypatch.delenv("AXON_CUDA", raising=False)
+        mock_te_cls.return_value = MagicMock()
+
+        _get_model("test-model")
+
+        _, kwargs = mock_te_cls.call_args
+        assert not kwargs.get("cuda")
+
+    @patch("fastembed.TextEmbedding")
+    def test_cuda_cache_key_separation(
+        self, mock_te_cls: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CUDA and non-CUDA models are cached under separate keys."""
+        monkeypatch.delenv("AXON_CUDA", raising=False)
+        mock_te_cls.return_value = MagicMock()
+
+        _get_model("test-model")
+        try:
+            configure_cuda(True)
+            _get_model("test-model")
+        finally:
+            configure_cuda(False)
+
+        assert mock_te_cls.call_count == 2
+
+    @patch("fastembed.TextEmbedding")
+    def test_cuda_fallback_raises_runtime_error(
+        self, mock_te_cls: MagicMock
+    ) -> None:
+        """RuntimeWarning with CUDAExecutionProvider is re-raised as RuntimeError."""
+        def _emit_cuda_warning(*args: object, **kwargs: object) -> MagicMock:
+            warnings.warn(
+                "CUDAExecutionProvider not available", RuntimeWarning
+            )
+            return MagicMock()
+
+        mock_te_cls.side_effect = _emit_cuda_warning
+        try:
+            configure_cuda(True)
+            with pytest.raises(RuntimeError, match="CUDAExecutionProvider"):
+                _get_model("test-model")
+        finally:
+            configure_cuda(False)
+
+    @patch("fastembed.TextEmbedding")
+    def test_validate_cuda_noop_when_disabled(
+        self, mock_te_cls: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """validate_cuda does not load the model when CUDA is disabled."""
+        monkeypatch.delenv("AXON_CUDA", raising=False)
+
+        validate_cuda()
+
+        mock_te_cls.assert_not_called()
+
+    @patch("fastembed.TextEmbedding")
+    def test_validate_cuda_raises_on_fallback(
+        self, mock_te_cls: MagicMock
+    ) -> None:
+        """validate_cuda propagates RuntimeError when CUDA provider fails."""
+        def _emit_cuda_warning(*args: object, **kwargs: object) -> MagicMock:
+            warnings.warn(
+                "CUDAExecutionProvider not available", RuntimeWarning
+            )
+            return MagicMock()
+
+        mock_te_cls.side_effect = _emit_cuda_warning
+        try:
+            configure_cuda(True)
+            with pytest.raises(RuntimeError, match="CUDAExecutionProvider"):
+                validate_cuda()
+        finally:
+            configure_cuda(False)

--- a/tests/core/test_embedder.py
+++ b/tests/core/test_embedder.py
@@ -133,7 +133,7 @@ class TestModelDefaults:
         assert _DEFAULT_DIMENSIONS == 384
 
     def test_default_batch_size(self) -> None:
-        assert _DEFAULT_BATCH_SIZE == 32
+        assert _DEFAULT_BATCH_SIZE == 8
 
 
 class TestEmbeddableLabels:
@@ -438,7 +438,7 @@ class TestEmbedGraphBatchProcessing:
         assert all(len(r.embedding) == EMBEDDING_DIMENSIONS for r in results)
 
     @patch("fastembed.TextEmbedding")
-    def test_default_batch_size_is_32(
+    def test_default_batch_size_is_8(
         self, mock_te_cls: MagicMock, sample_graph: KnowledgeGraph
     ) -> None:
         mock_model = MagicMock()
@@ -450,8 +450,8 @@ class TestEmbedGraphBatchProcessing:
         embed_graph(sample_graph)
 
         embed_call = mock_model.passage_embed.call_args
-        assert embed_call.kwargs.get("batch_size") == 32 or (
-            len(embed_call.args) > 1 and embed_call.args[1] == 32
+        assert embed_call.kwargs.get("batch_size") == 8 or (
+            len(embed_call.args) > 1 and embed_call.args[1] == 8
         )
 
 


### PR DESCRIPTION
## Summary

Closes #64.

Adds opt-in CUDA support for the embedding pipeline, reducing embedding time from minutes to seconds on GPU-capable machines.

Two activation paths:
- `--cuda` CLI flag on `analyze`, `watch`, `host`, and `serve`
- `AXON_CUDA=1` environment variable (works across all commands without per-command flags)

### Design

Uses a **module-level configuration** in `embedder.py` rather than threading a `cuda` parameter through every function signature. `_get_model()` reads the CUDA state at call time via `_resolve_cuda()`, which checks both the programmatic flag and the env var. This means all embedding call sites — pipeline, watcher, and search-time `embed_query()` from MCP/web — automatically use GPU when enabled.

### CUDA validation

When CUDA is requested, `_get_model()` captures fastembed's `RuntimeWarning` on `CUDAExecutionProvider` fallback and converts it to a `RuntimeError` with actionable install instructions. CLI commands call `validate_cuda()` **before** the pipeline starts, so the error surfaces immediately rather than being swallowed by the pipeline's broad `except Exception` handler.

### Changes

- **`src/axon/core/embeddings/embedder.py`** — `configure_cuda()`, `_resolve_cuda()`, `validate_cuda()`. `_get_model()` uses `(model_name, cuda)` compound cache key and post-init CUDA fallback detection.
- **`src/axon/cli/main.py`** — `_configure_and_validate_cuda()` helper. `--cuda` flag on `analyze`, `watch`, `host`, `serve`.
- **`tests/core/test_embedder.py`** — 15 new tests covering flag, env var, cache separation, fallback detection.

## Usage

```bash
# Via CLI flag
axon analyze --cuda .

# Via environment variable (works with any command)
export AXON_CUDA=1
axon analyze .
axon watch
axon host
```