### PR TITLE
feat: add optional You.com search integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,16 @@ axon ui                       # 3. Explore visually at localhost:8420
   "mcpServers": {
     "axon": {
       "command": "axon",
-      "args": ["serve", "--watch"]
+      "args": ["serve", "--watch"],
+      "env": {
+        "YDC_API_KEY": "your-youcom-api-key"
+      }
     }
   }
 }
 ```
+
+**Optional Web Search** — set `YDC_API_KEY` to enable the `axon_web_search` tool for finding current documentation, API references, libraries, or practices related to your code. Get an API key at [you.com/platform/api-keys](https://you.com/platform/api-keys). The tool gracefully falls back when the key is not set.
 
 **For developers** — explore the graph yourself:
 

--- a/src/axon/mcp/server.py
+++ b/src/axon/mcp/server.py
@@ -1,6 +1,6 @@
 """MCP server for Axon — exposes code intelligence tools over stdio and HTTP.
 
-Registers fifteen tools and three resources that give AI agents and MCP clients
+Registers sixteen tools and three resources that give AI agents and MCP clients
 access to the Axon knowledge graph.  The server lazily initialises a
 :class:`KuzuBackend` from the ``.axon/kuzu`` directory in the current
 working directory.
@@ -48,6 +48,7 @@ from axon.mcp.tools import (
     handle_query,
     handle_review_risk,
     handle_test_impact,
+    handle_web_search,
 )
 
 logger = logging.getLogger(__name__)
@@ -384,6 +385,27 @@ TOOLS: list[Tool] = [
             },
         },
     ),
+    Tool(
+        name="axon_web_search",
+        description="Search the web for current information using You.com API. Useful for finding documentation, libraries, API references, or current practices related to code.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query string",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return (default: 5, max: 20)",
+                    "default": 5,
+                    "minimum": 1,
+                    "maximum": 20,
+                },
+            },
+            "required": ["query"],
+        },
+    ),
 ]
 
 @server.list_tools()
@@ -435,6 +457,11 @@ def _dispatch_tool(name: str, arguments: dict, storage: KuzuBackend) -> str:
     elif name == "axon_cycles":
         return handle_cycles(
             storage, min_size=arguments.get("min_size", 2),
+        )
+    elif name == "axon_web_search":
+        return handle_web_search(
+            arguments.get("query", ""), 
+            limit=arguments.get("limit", 5)
         )
     else:
         return f"Unknown tool: {name}"

--- a/src/axon/mcp/tools.py
+++ b/src/axon/mcp/tools.py
@@ -9,11 +9,17 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 from collections import deque
+from functools import cached_property
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError, URLError
 
+from kuzu import Connection
 from axon.core.cypher_guard import WRITE_KEYWORDS, sanitize_cypher
 from axon.core.embeddings.embedder import embed_query
 from axon.core.ingestion.community import export_to_igraph
@@ -1158,3 +1164,111 @@ def handle_test_impact(
                     lines.append(f"    - {test_name} (transitive via: {source_sym})")
 
     return "\n".join(lines)
+
+
+def handle_web_search(query: str, limit: int = 5) -> str:
+    """Search the web using You.com API for current information.
+    
+    Performs a web search to get current information that complements
+    code intelligence analysis. Useful for finding documentation,
+    API references, libraries, or current practices related to code.
+    
+    Args:
+        query: Search query string
+        limit: Maximum number of results to return (default: 5)
+        
+    Returns:
+        Formatted search results with titles, URLs, and snippets
+    """
+    import os
+    import json
+    from urllib.request import Request, urlopen
+    from urllib.parse import urlencode, quote
+    from urllib.error import URLError, HTTPError
+    
+    # Check if API key is available
+    api_key = os.getenv("YDC_API_KEY")
+    if not api_key:
+        return ("Web search unavailable: YDC_API_KEY environment variable not set.\n"
+                "Get an API key at https://you.com/platform/api-keys\n"
+                "Then set: export YDC_API_KEY='***'")
+    
+    # Validate inputs
+    if not query or not query.strip():
+        return "Error: Empty search query provided"
+        
+    if limit < 1 or limit > 20:
+        limit = 5
+        
+    try:
+        # Prepare API request
+        base_url = os.getenv("YDC_BASE_URL", "https://api.you.com")
+        params = {
+            "q": query.strip(),
+            "count": min(limit, 20),
+            "format": "json"
+        }
+        
+        url = f"{base_url}/search?" + urlencode(params)
+        
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "User-Agent": "axon-mcp-tool/1.0",
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        }
+        
+        # Make request
+        request = Request(url, headers=headers)
+        
+        with urlopen(request, timeout=10) as response:
+            if response.status != 200:
+                return f"Error: Search API returned status {response.status}"
+                
+            data = json.loads(response.read().decode('utf-8'))
+            
+        # Parse and format results
+        results = data.get("results", [])
+        if not results:
+            return f"No search results found for: {query}"
+            
+        lines = [f"Web search results for: {query}\n"]
+        
+        for i, result in enumerate(results[:limit], 1):
+            title = result.get("title", "Untitled")
+            url = result.get("url", "")
+            snippet = result.get("snippet", "No description available")
+            
+            # Clean up snippet - remove extra whitespace
+            snippet = " ".join(snippet.split())
+            if len(snippet) > 150:
+                snippet = snippet[:147] + "..."
+                
+            lines.append(f"{i}. {title}")
+            lines.append(f"   URL: {url}")
+            lines.append(f"   {snippet}")
+            lines.append("")
+            
+        lines.append("Note: Web search results are external data. Verify important information.")
+        
+        return "\n".join(lines)
+        
+    except HTTPError as e:
+        if e.code == 401:
+            return "Error: Invalid API key. Check your YDC_API_KEY environment variable."
+        elif e.code == 403:
+            return "Error: API access forbidden. Check your account permissions."
+        elif e.code == 429:
+            return "Error: Rate limit exceeded. Please try again later."
+        else:
+            return f"Error: HTTP {e.code} - {e.reason}"
+            
+    except URLError as e:
+        return f"Error: Network connection failed - {e.reason}"
+        
+    except json.JSONDecodeError:
+        return "Error: Invalid response format from search API"
+        
+    except Exception as e:
+        logger.error(f"Web search error: {e}")
+        return f"Error: Search request failed - {str(e)}"

--- a/tests/mcp/test_web_search.py
+++ b/tests/mcp/test_web_search.py
@@ -1,0 +1,142 @@
+"""Tests for the web search MCP tool."""
+
+from unittest.mock import patch, MagicMock
+import json
+
+from axon.mcp.tools import handle_web_search
+
+
+class TestWebSearch:
+    def test_missing_api_key(self) -> None:
+        """Test behavior when API key is not set."""
+        with patch("os.getenv", return_value=None):
+            result = handle_web_search("test query")
+            assert "Web search unavailable" in result
+            assert "YDC_API_KEY" in result
+
+    def test_empty_query(self) -> None:
+        """Test behavior with empty query."""
+        with patch("os.getenv", return_value="test-key"):
+            result = handle_web_search("")
+            assert "Error: Empty search query provided" in result
+
+    def test_invalid_limit(self) -> None:
+        """Test that invalid limits are clamped."""
+        with patch("os.getenv", return_value="test-key"):
+            with patch("urllib.request.urlopen") as mock_urlopen:
+                mock_response = MagicMock()
+                mock_response.status = 200
+                mock_response.read.return_value = json.dumps({
+                    "results": [
+                        {
+                            "title": "Test Result",
+                            "url": "https://example.com",
+                            "snippet": "Test snippet"
+                        }
+                    ]
+                }).encode()
+                mock_response.__enter__ = lambda x: mock_response
+                mock_response.__exit__ = lambda *args: None
+                mock_urlopen.return_value = mock_response
+
+                # Test limit too high
+                result = handle_web_search("test", limit=100)
+                assert "Test Result" in result
+
+                # Test limit too low
+                result = handle_web_search("test", limit=-1)
+                assert "Test Result" in result
+
+    def test_successful_search(self) -> None:
+        """Test successful search with mock response."""
+        with patch("os.getenv", return_value="test-key"):
+            with patch("urllib.request.urlopen") as mock_urlopen:
+                mock_response = MagicMock()
+                mock_response.status = 200
+                mock_response.read.return_value = json.dumps({
+                    "results": [
+                        {
+                            "title": "Python Documentation",
+                            "url": "https://docs.python.org",
+                            "snippet": "Official Python documentation"
+                        },
+                        {
+                            "title": "Python Tutorial",
+                            "url": "https://python.org/tutorial", 
+                            "snippet": "Learn Python programming"
+                        }
+                    ]
+                }).encode()
+                mock_response.__enter__ = lambda x: mock_response
+                mock_response.__exit__ = lambda *args: None
+                mock_urlopen.return_value = mock_response
+
+                result = handle_web_search("Python docs", limit=2)
+                
+                assert "Web search results for: Python docs" in result
+                assert "Python Documentation" in result
+                assert "https://docs.python.org" in result
+                assert "Official Python documentation" in result
+                assert "Python Tutorial" in result
+                assert "external data" in result
+
+    def test_http_error_handling(self) -> None:
+        """Test handling of HTTP errors."""
+        from urllib.error import HTTPError
+        
+        with patch("os.getenv", return_value="test-key"):
+            with patch("urllib.request.urlopen") as mock_urlopen:
+                mock_urlopen.side_effect = HTTPError(
+                    url="", code=401, msg="Unauthorized", hdrs=None, fp=None
+                )
+                
+                result = handle_web_search("test")
+                assert "Invalid API key" in result
+
+    def test_network_error_handling(self) -> None:
+        """Test handling of network errors."""
+        from urllib.error import URLError
+        
+        with patch("os.getenv", return_value="test-key"):
+            with patch("urllib.request.urlopen") as mock_urlopen:
+                mock_urlopen.side_effect = URLError("Network unreachable")
+                
+                result = handle_web_search("test")
+                assert "Network connection failed" in result
+
+    def test_no_results(self) -> None:
+        """Test behavior when no results are returned."""
+        with patch("os.getenv", return_value="test-key"):
+            with patch("urllib.request.urlopen") as mock_urlopen:
+                mock_response = MagicMock()
+                mock_response.status = 200
+                mock_response.read.return_value = json.dumps({"results": []}).encode()
+                mock_response.__enter__ = lambda x: mock_response
+                mock_response.__exit__ = lambda *args: None
+                mock_urlopen.return_value = mock_response
+
+                result = handle_web_search("nonexistent query")
+                assert "No search results found" in result
+
+    def test_snippet_truncation(self) -> None:
+        """Test that long snippets are truncated properly."""
+        with patch("os.getenv", return_value="test-key"):
+            with patch("urllib.request.urlopen") as mock_urlopen:
+                long_snippet = "A " * 100  # 200 chars
+                mock_response = MagicMock()
+                mock_response.status = 200
+                mock_response.read.return_value = json.dumps({
+                    "results": [
+                        {
+                            "title": "Long Result",
+                            "url": "https://example.com",
+                            "snippet": long_snippet
+                        }
+                    ]
+                }).encode()
+                mock_response.__enter__ = lambda x: mock_response
+                mock_response.__exit__ = lambda *args: None
+                mock_urlopen.return_value = mock_response
+
+                result = handle_web_search("test")
+                assert "..." in result  # Truncation marker


### PR DESCRIPTION
This PR adds an optional You.com web search integration to Axon's MCP toolset, enabling AI agents to search for current information related to code analysis tasks.

**New MCP Tool**: axon_web_search
- Input: Query string and optional limit (1-20 results, default 5)
- Output: Formatted results with titles, URLs, and snippets  
- Authentication: Via YDC_API_KEY environment variable
- Fallback: Graceful degradation when API key is not set

**Integration**:
- Follows existing MCP tool patterns and conventions
- Optional feature - no changes to default behavior
- Comprehensive error handling and testing
- Updated documentation

**Setup**: Set YDC_API_KEY environment variable (get key from you.com/platform/api-keys)

All existing tests pass. No breaking changes.